### PR TITLE
add event dispatcher

### DIFF
--- a/lib/module-for.js
+++ b/lib/module-for.js
@@ -34,6 +34,9 @@ export default function moduleFor(fullName, description, callbacks, delegate) {
   }
 
   var context = testContext.get();
+  // TODO: move this to component|view callbacks when infrastructure is added
+  // to make it simpler
+  var dispatcher = Ember.EventDispatcher.create();
   var _callbacks = {
     setup: function(){
       Ember.$('<div id="ember-testing"/>').appendTo(document.body);
@@ -44,6 +47,7 @@ export default function moduleFor(fullName, description, callbacks, delegate) {
     teardown: function(){
       Ember.run(function(){
         container.destroy();
+        dispatcher.destroy();
       });
       Ember.$('#ember-testing').empty();
       callbacks.teardown(container);


### PR DESCRIPTION
Allows tests to interact with components.

For now, its in every setup/teardown, but we only
need it for components and views. We need some
infrastructure to make adding setup and teardown
logic for each moduleFor\* method to be simpler,
and when we have that, we'll move the dispatcher
there.
