### PR TITLE
Remove unnecessary #ember-testing append in moduleFor.

### DIFF
--- a/lib/module-for-component.js
+++ b/lib/module-for-component.js
@@ -21,7 +21,7 @@ export default function moduleForComponent(name, description, callbacks) {
         var subject = context.subject();
         containerView.pushObject(subject);
         // TODO: destory this somewhere
-        containerView.appendTo(Ember.$('#ember-testing')[0]);
+        containerView.appendTo('#ember-testing');
         return subject;
       });
 

--- a/lib/module-for.js
+++ b/lib/module-for.js
@@ -41,7 +41,9 @@ export default function moduleFor(fullName, description, callbacks, delegate) {
     setup: function(){
       container = isolatedContainer(needs);
       dispatcher.setup();
-      Ember.$('<div id="ember-testing"/>').appendTo(document.body);
+      if (Ember.$('#ember-testing').length === 0) {
+        Ember.$('<div id="ember-testing"/>').appendTo(document.body);
+      }
       buildContextVariables(context);
       callbacks.setup.call(context, container);
     },

--- a/test/support/setup.js
+++ b/test/support/setup.js
@@ -6,3 +6,4 @@ Array.prototype.compile = function() {
   return Ember.Handlebars.compile(this.join('\n'));
 };
 
+document.write('<div id="ember-testing"></div>');


### PR DESCRIPTION
I noticed that moduleFor was creating a new `#ember-testing` div on each test. Additionally, these divs are not even used for testing (the Ember app is set up to render to the `#ember-testing-container > #ember-testing` div).
