### PR TITLE
removes the new isolatedContainer in setup

### DIFF
--- a/lib/module-for.js
+++ b/lib/module-for.js
@@ -39,7 +39,6 @@ export default function moduleFor(fullName, description, callbacks, delegate) {
   var dispatcher = Ember.EventDispatcher.create();
   var _callbacks = {
     setup: function(){
-      container = isolatedContainer(needs);
       dispatcher.setup();
       if (Ember.$('#ember-testing').length === 0) {
         Ember.$('<div id="ember-testing"/>').appendTo(document.body);
@@ -50,7 +49,7 @@ export default function moduleFor(fullName, description, callbacks, delegate) {
 
     teardown: function(){
       Ember.run(function(){
-        container.destroy();
+        container.reset();
         dispatcher.destroy();
       });
       Ember.$('#ember-testing').empty();

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -9,8 +9,18 @@ var Comment = DS.Model.extend({
   post: DS.belongsTo('post')
 });
 
+var PrettyColor = Ember.Component.extend({
+  classNames: ['pretty-color'],
+  attributeBindings: ['style'],
+  style: function(){
+    return 'color: ' + this.get('name') + ';';
+  }.property('name')
+});
+
 var registry = {
   'component:x-foo': Ember.Component.extend(),
+  'component:pretty-color': PrettyColor,
+  'template:components/pretty-color': "Pretty Color: {{name}}".compile(),
   'route:foo': Ember.Route.extend(),
   'controller:foos': Ember.ArrayController.extend(),
   'controller:bar': Ember.Controller.extend({
@@ -122,3 +132,21 @@ test('clears out views from test to test', function() {
   ok(true, 'rendered without id already being used from another test');
 });
 
+moduleForComponent('pretty-color', 'moduleForComponent with pretty-color');
+
+test("className", function(){
+  // first call to this.$() renders the component.
+  ok(this.$().is('.pretty-color'));
+});
+
+test("template", function(){
+  var component = this.subject();
+
+  equal($.trim(this.$().text()), 'Pretty Color:');
+
+  Ember.run(function(){
+    component.set('name', 'green');
+  });
+
+  equal($.trim(this.$().text()), 'Pretty Color: green');
+});


### PR DESCRIPTION
removes the new isolatedContainer in setup and instead does a `container.reset()` in teardown.

see https://github.com/stefanpenner/ember-app-kit/issues/568 for the reason.

i'm not sure if it's the right way to go but i added tests for the component and all test (including the controller needs tests) are green.

@stefanpenner @rpflorence any objections?
