### PR TITLE
allow for skipping of cleanup if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,23 @@ Helpers
 - `name`: (String) - the short name of the model you'd use in `store`
   operations ie `user`, `assignmentGroup`, etc.
 
+### Skipping teardown
+
+- when testing components you sometimes want to use the thing in the
+  browser as you develop. This can be done on an individual test by
+  setting noCleanup to true. (This should be used like a debugger, so
+  should be removed after building the test otherwise it will break
+  other tests).
+
+```js
+test('it renders', function() {
+  this.noCleanup = true;
+  this.append();
+  equal(component.state, 'inDOM');
+});
+```
+
+
 Contributing
 ------------
 

--- a/lib/module-for.js
+++ b/lib/module-for.js
@@ -45,16 +45,19 @@ export default function moduleFor(fullName, description, callbacks, delegate) {
     },
 
     teardown: function(){
-      Ember.run(function(){
-        container.destroy();
-        
-        if (context.dispatcher) {
-          context.dispatcher.destroy();
-        }
-      });
-      
+      //Allow users to skip teardown for an individual test
+      if (!context.noCleanup){
+        Ember.run(function(){
+          container.destroy();
+
+          if (context.dispatcher) {
+            context.dispatcher.destroy();
+          }
+        });
+
+        Ember.$('#ember-testing').empty();
+      }
       callbacks.teardown(container);
-      Ember.$('#ember-testing').empty();
     }
   };
 


### PR DESCRIPTION
for issue #6, we've found ourselves wanting to look at the rendered output of controllers often as we are writing tests. With old integration tests that was super easy to do, but ember-qunit blows everything away. 

Adding noCleanup will allow people to view the results of their test in the browser as they run them, hopefully allowing for easier debugging.
