### PR TITLE
to run broccoli serve you need broccoli-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Contributing
 ```sh
 $ npm install
 $ bower install
-$ npm install -g karma-cli
+$ npm install -g karma-cli broccoli-cli
 $ broccoli serve
 # new tab
 $ karma start


### PR DESCRIPTION
I followed the `Contributing` steps and couldn't make it working without installing `broccoli-cli` globally.
