### PR TITLE
Add extra helpers.

### DIFF
--- a/lib/equal.js
+++ b/lib/equal.js
@@ -1,0 +1,7 @@
+import QUnit from 'qunit';
+import getAssertionMessage from './get-assertion-message';
+
+export default function equal(actual, expected, message) {
+  message = getAssertionMessage(actual, expected, message);
+  QUnit.equal.call(this, actual, expected, message);
+}

--- a/lib/get-assertion-message.js
+++ b/lib/get-assertion-message.js
@@ -1,0 +1,5 @@
+import QUnit from 'qunit';
+
+export default function getAssertionMessage(actual, expected, message) {
+  return message || QUnit.jsDump.parse(expected) + " expected but was " + QUnit.jsDump.parse(actual);
+}

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,9 +1,12 @@
-import Ember              from 'ember';
-import isolatedContainer  from './isolated-container';
-import moduleFor          from './module-for';
-import moduleForComponent from './module-for-component';
-import test               from './test';
-import testResolver       from './test-resolver';
+import Ember               from 'ember';
+import isolatedContainer   from './isolated-container';
+import moduleFor           from './module-for';
+import moduleForComponent  from './module-for-component';
+import test                from './test';
+import testResolver        from './test-resolver';
+import equal               from './equal';
+import getAssertionMessage from './get-assertion-message';
+import strictEqual         from './strict-equal';
 
 Ember.testing = true;
 
@@ -16,6 +19,9 @@ function globalize() {
   window.moduleForComponent = moduleForComponent;
   window.test = test;
   window.setResolver = setResolver;
+  window.equal = equal;
+  window.strictEqual = strictEqual;
+  window.getAssertionMessage = getAssertionMessage;
 }
 
 export {
@@ -23,6 +29,8 @@ export {
   moduleFor,
   moduleForComponent,
   test,
-  setResolver
+  setResolver,
+  equal,
+  strictEqual,
+  getAssertionMessage
 };
-

--- a/lib/strict-equal.js
+++ b/lib/strict-equal.js
@@ -1,0 +1,7 @@
+import QUnit from 'qunit';
+import getAssertionMessage from './get-assertion-message';
+
+export default function strictEqual(actual, expected, message) {
+  message = getAssertionMessage(actual, expected, message);
+  QUnit.strictEqual.call(this, actual, expected, message);
+}


### PR DESCRIPTION
The added helpers were being defined  on `tests/test-helpers`, but we
don't have to do it there since they are related with QUnit.
