### PR TITLE
Pass the selector to this.$(...) helper in component tests

### DIFF
--- a/lib/module-for-component.js
+++ b/lib/module-for-component.js
@@ -28,7 +28,7 @@ export default function moduleForComponent(name, description, callbacks) {
         return subject;
       });
 
-      return view.$();
+      return view.$(selector);
     };
     context.__setup_properties__.$ = context.__setup_properties__.append;
   });

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -32,7 +32,7 @@ var ApplicationAdapter = DS.FixtureAdapter.extend();
 var registry = {
   'component:x-foo': Ember.Component.extend(),
   'component:pretty-color': PrettyColor,
-  'template:components/pretty-color': "Pretty Color: {{name}}".compile(),
+  'template:components/pretty-color': 'Pretty Color: <span class="color-name">{{name}}</span>'.compile(),
   'route:foo': Ember.Route.extend(),
   'controller:foos': Ember.ArrayController.extend(),
   'controller:bar': Ember.Controller.extend({
@@ -231,4 +231,9 @@ test("template", function(){
   });
 
   equal($.trim(this.$().text()), 'Pretty Color: green');
+});
+
+test("selector", function(){
+  var component = this.subject({name: 'green'});
+  equal($.trim(this.$('.color-name').text()), 'green');
 });


### PR DESCRIPTION
I tried doing `this.$('.some-child-element-in-the-component')` in my component tests and it actually ignored the selector and just returned the component, which was very confusing. I applied this patch on my setup and it seems to work fine.

However, when I tried to run the tests locally, I'm getting a lot of unrelated (I think?) failures/errors, so I'm unsure if I actually broke something.
