### PR TITLE
Fixed `this.$(selector)` returning cached result

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ test('it renders', function() {
   var component = this.subject();
   equal(component.state, 'preRender');
 
-  // appends the component to the page
-  this.append();
+  // render the component on the page
+  this.render();
   equal(component.state, 'inDOM');
 });
 ```
@@ -94,7 +94,7 @@ test('selects first tab and shows the panel', function() {
       '{{#ic-tab-panel id="panel3"}}three{{/ic-tab-panel}}'
     })
   });
-  this.append();
+  this.render();
   var tab1 = Ember.View.views['tab1'];
   var panel1 = Ember.View.views['panel1'];
   ok(component.get('activeTab') === tab1);
@@ -188,4 +188,3 @@ $ broccoli build dist
 # Broccoli will not overwrite dist/, so you
 # may need to delete it first
 ```
-

--- a/dist/amd/module-for-component.js
+++ b/dist/amd/module-for-component.js
@@ -22,7 +22,7 @@ define(
         context.dispatcher = Ember.EventDispatcher.create();
         context.dispatcher.setup({}, '#ember-testing');
 
-        context.__setup_properties__.append = function(selector) {
+        context.__setup_properties__.render = function() {
           var containerView = Ember.ContainerView.create({container: container});
           var view = Ember.run(function(){
             var subject = context.subject();
@@ -34,7 +34,21 @@ define(
 
           return view.$();
         };
-        context.__setup_properties__.$ = context.__setup_properties__.append;
+
+        context.__setup_properties__.append = function(){
+          Ember.deprecate('this.append() is deprecated. Please use this.render() instead.');
+          return this.render();
+        };
+
+        context.$ = function(){
+          var $view = this.render(), subject = this.subject();
+
+          if(arguments.length){
+            return subject.$.apply(subject, arguments);
+          }else{
+            return $view;
+          }
+        };
       });
     }
   });

--- a/dist/amd/module-for-model.js
+++ b/dist/amd/module-for-model.js
@@ -6,6 +6,8 @@ define(
     var Ember = __dependency2__["default"] || __dependency2__;
 
     __exports__["default"] = function moduleForModel(name, description, callbacks) {
+      if (!DS) throw new Error('You must have Ember Data installed to use `moduleForModel`.');
+
       moduleFor('model:' + name, description, callbacks, function(container, context, defaultSubject) {
         if (DS._setupContainer) {
           DS._setupContainer(container);

--- a/dist/cjs/module-for-component.js
+++ b/dist/cjs/module-for-component.js
@@ -19,7 +19,7 @@ exports["default"] = function moduleForComponent(name, description, callbacks) {
     context.dispatcher = Ember.EventDispatcher.create();
     context.dispatcher.setup({}, '#ember-testing');
 
-    context.__setup_properties__.append = function(selector) {
+    context.__setup_properties__.render = function() {
       var containerView = Ember.ContainerView.create({container: container});
       var view = Ember.run(function(){
         var subject = context.subject();
@@ -31,6 +31,20 @@ exports["default"] = function moduleForComponent(name, description, callbacks) {
 
       return view.$();
     };
-    context.__setup_properties__.$ = context.__setup_properties__.append;
+
+    context.__setup_properties__.append = function(){
+      Ember.deprecate('this.append() is deprecated. Please use this.render() instead.');
+      return this.render();
+    };
+
+    context.$ = function(){
+      var $view = this.render(), subject = this.subject();
+
+      if(arguments.length){
+        return subject.$.apply(subject, arguments);
+      }else{
+        return $view;
+      }
+    };
   });
 }

--- a/dist/cjs/module-for-model.js
+++ b/dist/cjs/module-for-model.js
@@ -3,6 +3,8 @@ var moduleFor = require("./module-for")["default"] || require("./module-for");
 var Ember = require("ember")["default"] || require("ember");
 
 exports["default"] = function moduleForModel(name, description, callbacks) {
+  if (!DS) throw new Error('You must have Ember Data installed to use `moduleForModel`.');
+
   moduleFor('model:' + name, description, callbacks, function(container, context, defaultSubject) {
     if (DS._setupContainer) {
       DS._setupContainer(container);

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -69,7 +69,7 @@ exports["default"] = function moduleForComponent(name, description, callbacks) {
     context.dispatcher = Ember.EventDispatcher.create();
     context.dispatcher.setup({}, '#ember-testing');
 
-    context.__setup_properties__.append = function(selector) {
+    context.__setup_properties__.render = function() {
       var containerView = Ember.ContainerView.create({container: container});
       var view = Ember.run(function(){
         var subject = context.subject();
@@ -81,7 +81,21 @@ exports["default"] = function moduleForComponent(name, description, callbacks) {
 
       return view.$();
     };
-    context.__setup_properties__.$ = context.__setup_properties__.append;
+
+    context.__setup_properties__.append = function(){
+      Ember.deprecate('this.append() is deprecated. Please use this.render() instead.');
+      return this.render();
+    };
+
+    context.$ = function(){
+      var $view = this.render(), subject = this.subject();
+
+      if(arguments.length){
+        return subject.$.apply(subject, arguments);
+      }else{
+        return $view;
+      }
+    };
   });
 }
 },{"./module-for":5,"./test-resolver":7}],4:[function(_dereq_,module,exports){
@@ -90,6 +104,8 @@ var moduleFor = _dereq_("./module-for")["default"] || _dereq_("./module-for");
 var Ember = window.Ember["default"] || window.Ember;
 
 exports["default"] = function moduleForModel(name, description, callbacks) {
+  if (!DS) throw new Error('You must have Ember Data installed to use `moduleForModel`.');
+
   moduleFor('model:' + name, description, callbacks, function(container, context, defaultSubject) {
     if (DS._setupContainer) {
       DS._setupContainer(container);

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -19,7 +19,8 @@ define("ember-qunit/isolated-container",
       }
       return container;
     }
-  });define("ember-qunit",
+  });
+define("ember-qunit",
   ["ember","./isolated-container","./module-for","./module-for-component","./module-for-model","./test","./test-resolver","exports"],
   function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, __dependency5__, __dependency6__, __dependency7__, __exports__) {
     "use strict";
@@ -51,7 +52,8 @@ define("ember-qunit/isolated-container",
     __exports__.moduleForModel = moduleForModel;
     __exports__.test = test;
     __exports__.setResolver = setResolver;
-  });define("ember-qunit/module-for-component",
+  });
+define("ember-qunit/module-for-component",
   ["./test-resolver","./module-for","ember","exports"],
   function(__dependency1__, __dependency2__, __dependency3__, __exports__) {
     "use strict";
@@ -75,7 +77,7 @@ define("ember-qunit/isolated-container",
         context.dispatcher = Ember.EventDispatcher.create();
         context.dispatcher.setup({}, '#ember-testing');
 
-        context.__setup_properties__.append = function(selector) {
+        context.__setup_properties__.render = function() {
           var containerView = Ember.ContainerView.create({container: container});
           var view = Ember.run(function(){
             var subject = context.subject();
@@ -87,10 +89,25 @@ define("ember-qunit/isolated-container",
 
           return view.$();
         };
-        context.__setup_properties__.$ = context.__setup_properties__.append;
+
+        context.__setup_properties__.append = function(){
+          Ember.deprecate('this.append() is deprecated. Please use this.render() instead.');
+          return this.render();
+        };
+
+        context.$ = function(){
+          var $view = this.render(), subject = this.subject();
+
+          if(arguments.length){
+            return subject.$.apply(subject, arguments);
+          }else{
+            return $view;
+          }
+        };
       });
     }
-  });define("ember-qunit/module-for-model",
+  });
+define("ember-qunit/module-for-model",
   ["./module-for","ember","exports"],
   function(__dependency1__, __dependency2__, __exports__) {
     "use strict";
@@ -98,6 +115,8 @@ define("ember-qunit/isolated-container",
     var Ember = __dependency2__["default"] || __dependency2__;
 
     __exports__["default"] = function moduleForModel(name, description, callbacks) {
+      if (!DS) throw new Error('You must have Ember Data installed to use `moduleForModel`.');
+
       moduleFor('model:' + name, description, callbacks, function(container, context, defaultSubject) {
         if (DS._setupContainer) {
           DS._setupContainer(container);
@@ -123,7 +142,8 @@ define("ember-qunit/isolated-container",
         }
       });
     }
-  });define("ember-qunit/module-for",
+  });
+define("ember-qunit/module-for",
   ["ember","./test-context","./isolated-container","exports"],
   function(__dependency1__, __dependency2__, __dependency3__, __exports__) {
     "use strict";
@@ -214,7 +234,8 @@ define("ember-qunit/isolated-container",
         };
       });
     }
-  });define("ember-qunit/test-context",
+  });
+define("ember-qunit/test-context",
   ["exports"],
   function(__exports__) {
     "use strict";
@@ -229,7 +250,8 @@ define("ember-qunit/isolated-container",
     }
 
     __exports__.get = get;
-  });define("ember-qunit/test-resolver",
+  });
+define("ember-qunit/test-resolver",
   ["exports"],
   function(__exports__) {
     "use strict";
@@ -245,7 +267,8 @@ define("ember-qunit/isolated-container",
     }
 
     __exports__.get = get;
-  });define("ember-qunit/test",
+  });
+define("ember-qunit/test",
   ["ember","./test-context","exports"],
   function(__dependency1__, __dependency2__, __exports__) {
     "use strict";

--- a/lib/module-for-component.js
+++ b/lib/module-for-component.js
@@ -18,7 +18,7 @@ export default function moduleForComponent(name, description, callbacks) {
     context.dispatcher = Ember.EventDispatcher.create();
     context.dispatcher.setup({}, '#ember-testing');
 
-    context.__setup_properties__.append = function(selector) {
+    context.__setup_properties__.render = function() {
       var containerView = Ember.ContainerView.create({container: container});
       var view = Ember.run(function(){
         var subject = context.subject();
@@ -28,8 +28,22 @@ export default function moduleForComponent(name, description, callbacks) {
         return subject;
       });
 
-      return view.$(selector);
+      return view.$();
     };
-    context.__setup_properties__.$ = context.__setup_properties__.append;
+
+    context.__setup_properties__.append = function(){
+      Ember.deprecate('this.append() is deprecated. Please use this.render() instead.');
+      return this.render();
+    };
+
+    context.$ = function(){
+      var $view = this.render(), subject = this.subject();
+
+      if(arguments.length){
+        return subject.$.apply(subject, arguments);
+      }else{
+        return $view;
+      }
+    };
   });
 }

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -182,8 +182,17 @@ test('renders', function() {
   expect(2);
   var component = this.subject();
   equal(component.state, 'preRender');
+  this.render();
+  equal(component.state, 'inDOM');
+});
+
+test('append', function() {
+  expect(3);
+  var component = this.subject();
+  equal(component.state, 'preRender');
   this.append();
   equal(component.state, 'inDOM');
+  equal(Ember.deprecationWarnings.pop(), 'this.append() is deprecated. Please use this.render() instead.');
 });
 
 test('yields', function() {
@@ -192,7 +201,7 @@ test('yields', function() {
     layout: "yield me".compile()
   });
   equal(component.state, 'preRender');
-  this.append();
+  this.render();
   equal(component.state, 'inDOM');
 });
 
@@ -201,7 +210,7 @@ test('can lookup components in its layout', function() {
   var component = this.subject({
     layout: "{{x-foo id='yodawg-i-heard-you-liked-x-foo-in-ur-x-foo'}}".compile()
   });
-  this.append();
+  this.render();
   equal(component.state, 'inDOM');
 });
 
@@ -210,7 +219,7 @@ test('clears out views from test to test', function() {
   var component = this.subject({
     layout: "{{x-foo id='yodawg-i-heard-you-liked-x-foo-in-ur-x-foo'}}".compile()
   });
-  this.append();
+  this.render();
   ok(true, 'rendered without id already being used from another test');
 });
 
@@ -233,7 +242,8 @@ test("template", function(){
   equal($.trim(this.$().text()), 'Pretty Color: green');
 });
 
-test("selector", function(){
+test("$", function(){
   var component = this.subject({name: 'green'});
   equal($.trim(this.$('.color-name').text()), 'green');
+  equal($.trim(this.$().text()), 'Pretty Color: green');
 });

--- a/test/support/setup.js
+++ b/test/support/setup.js
@@ -1,3 +1,9 @@
+Ember.deprecationWarnings = [];
+
+Ember.deprecate = function(message){
+  Ember.deprecationWarnings.push(message);
+};
+
 String.prototype.compile = function() {
   return Ember.Handlebars.compile(this);
 };


### PR DESCRIPTION
This is a slightly cleaned up version of my proposal in #55 for consideration :smile:
- Deprecated `this.append` in favor of `this.render` as discussed.
- Made `this.$(...)` an alias to `this.subject().$(...)` but it also ensures that the subject has been rendered into the DOM.

This seems to match my expectations quite nicely – my test suite is passing with this patch.

---

Existing usage of `this.$()` will continue to function the same way, while
`this.$(selector)` will work similarly to `this.subject().$(selector)` but
will first ensure that the subject has been rendered.

Also deprecated `this.append()` in favor of its new name, `this.render()` to
help better communicate its purpose.

Fixes #55.
