### PR TITLE
Do not require Ember Data.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,9 @@
     "test"
   ],
   "dependencies": {
-    "ember": "^1.3.0",
+    "ember": "^1.3.0"
+  },
+  "devDependencies": {
     "ember-data": "~1.0.0-beta.7"
   }
 }

--- a/lib/module-for-model.js
+++ b/lib/module-for-model.js
@@ -2,6 +2,8 @@ import moduleFor from './module-for';
 import Ember from 'ember';
 
 export default function moduleForModel(name, description, callbacks) {
+  if (!DS) throw new Error('You must have Ember Data installed to use `moduleForModel`.');
+
   moduleFor('model:' + name, description, callbacks, function(container, context, defaultSubject) {
     if (DS._setupContainer) {
       DS._setupContainer(container);


### PR DESCRIPTION
Currently, Ember Data is required and installed even if it is not needed. The majority of functionality in `ember-qunit` is related to Ember itself, but does not require Ember data.

This removes Ember Data as a runtime dependency, and adds a helpful error message if it is not found when attempting to use `moduleForModel`.
