### PR TITLE
test method accepts an optional `expected` argument

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -6,11 +6,15 @@ function resetViews() {
   Ember.View.views = {};
 }
 
-export default function test(testName, callback) {
+export default function test(testName, expected, callback) {
+  if (!callback) {
+    callback = expected;
+    expected = null;
+  }
 
   function wrapper() {
     var context = testContext.get();
-    
+
     resetViews();
     var result = callback.call(context);
 
@@ -24,6 +28,6 @@ export default function test(testName, callback) {
     });
   }
 
-  QUnit.test(testName, wrapper);
+  QUnit.test(testName, expected, wrapper);
 }
 

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -237,3 +237,8 @@ test("selector", function(){
   var component = this.subject({name: 'green'});
   equal($.trim(this.$('.color-name').text()), 'green');
 });
+
+test("test with expectations", 2, function(){
+  ok(true, 'expectation 1');
+  ok(true, 'expectation 2');
+});


### PR DESCRIPTION
QUnit.test can be called with the number of expectations (see https://github.com/jquery/qunit/blob/v1.14.0/qunit/qunit.js#L111).
This updates ember-qunit to allow this, also.

I added a test with this syntax. It would be better to have a test that shows that the expectation is honored (i.e., show that a test with 2 expectations but declared as `test('some name', 1, function()...)` would fail).
