### PR TITLE
[BUGFIX] Destroy components on teardown.

### DIFF
--- a/dist/amd/module-for-component.js
+++ b/dist/amd/module-for-component.js
@@ -27,10 +27,20 @@ define(
           var view = Ember.run(function(){
             var subject = context.subject();
             containerView.pushObject(subject);
-            // TODO: destory this somewhere
             containerView.appendTo('#ember-testing');
             return subject;
           });
+
+          var oldTeardown = this.teardown;
+          this.teardown = function() {
+            Ember.run(function() {
+              Ember.tryInvoke(containerView, 'destroy');
+            });
+
+            if (oldTeardown) {
+              return oldTeardown.apply(this, arguments);
+            }
+          };
 
           return view.$();
         };

--- a/dist/cjs/module-for-component.js
+++ b/dist/cjs/module-for-component.js
@@ -24,10 +24,20 @@ exports["default"] = function moduleForComponent(name, description, callbacks) {
       var view = Ember.run(function(){
         var subject = context.subject();
         containerView.pushObject(subject);
-        // TODO: destory this somewhere
         containerView.appendTo('#ember-testing');
         return subject;
       });
+
+      var oldTeardown = this.teardown;
+      this.teardown = function() {
+        Ember.run(function() {
+          Ember.tryInvoke(containerView, 'destroy');
+        });
+
+        if (oldTeardown) {
+          return oldTeardown.apply(this, arguments);
+        }
+      };
 
       return view.$();
     };

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -74,10 +74,20 @@ exports["default"] = function moduleForComponent(name, description, callbacks) {
       var view = Ember.run(function(){
         var subject = context.subject();
         containerView.pushObject(subject);
-        // TODO: destory this somewhere
         containerView.appendTo('#ember-testing');
         return subject;
       });
+
+      var oldTeardown = this.teardown;
+      this.teardown = function() {
+        Ember.run(function() {
+          Ember.tryInvoke(containerView, 'destroy');
+        });
+
+        if (oldTeardown) {
+          return oldTeardown.apply(this, arguments);
+        }
+      };
 
       return view.$();
     };

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -82,10 +82,20 @@ define("ember-qunit/module-for-component",
           var view = Ember.run(function(){
             var subject = context.subject();
             containerView.pushObject(subject);
-            // TODO: destory this somewhere
             containerView.appendTo('#ember-testing');
             return subject;
           });
+
+          var oldTeardown = this.teardown;
+          this.teardown = function() {
+            Ember.run(function() {
+              Ember.tryInvoke(containerView, 'destroy');
+            });
+
+            if (oldTeardown) {
+              return oldTeardown.apply(this, arguments);
+            }
+          };
 
           return view.$();
         };

--- a/lib/module-for-component.js
+++ b/lib/module-for-component.js
@@ -23,10 +23,20 @@ export default function moduleForComponent(name, description, callbacks) {
       var view = Ember.run(function(){
         var subject = context.subject();
         containerView.pushObject(subject);
-        // TODO: destory this somewhere
         containerView.appendTo('#ember-testing');
         return subject;
       });
+
+      var oldTeardown = this.teardown;
+      this.teardown = function() {
+        Ember.run(function() {
+          Ember.tryInvoke(containerView, 'destroy');
+        });
+
+        if (oldTeardown) {
+          return oldTeardown.apply(this, arguments);
+        }
+      };
 
       return view.$();
     };


### PR DESCRIPTION
I was experiencing the issue in #64 and needed some way to properly tear down a component after a test was completed, otherwise lingering event observers hung around. This fix solved the issues that I was having. However, I wasn't quite sure how to test the fix, since the real work happens in the test teardown. So if anybody has an idea for how to test this, let me know and I'll add some tests.
