### PR TITLE
Upgrade to QUnit 1.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "karma-requirejs": "~0.2.1",
     "karma-phantomjs-launcher": "~0.1.2",
     "karma": "~0.10.9",
-    "qunitjs": "~1.14.0",
+    "qunitjs": "~1.15.0",
     "karma-qunit": "~0.1.1",
     "bower": "^1.2.8",
     "broccoli-cli": "0.0.1"


### PR DESCRIPTION
Could we bump the version of QUnit? I'm using a feature on 1.15 that let's you configure select elements in the header of the browser test runner. This code doesn't work on the 1.14 branch.

I ran the tests locally and everything still passed.
