### PR TITLE
`isolated-container` should  call `resolver.normalize(fullName)` when resolving needs values.

### DIFF
--- a/dist/amd/isolated-container.js
+++ b/dist/amd/isolated-container.js
@@ -15,7 +15,8 @@ define(
       container.register('component-lookup:main', Ember.ComponentLookup);
       for (var i = fullNames.length; i > 0; i--) {
         var fullName = fullNames[i - 1];
-        container.register(fullName, resolver.resolve(fullName));
+        var normalizedFullName = resolver.normalize(fullName);
+        container.register(fullName, resolver.resolve(normalizedFullName));
       }
       return container;
     }

--- a/dist/cjs/isolated-container.js
+++ b/dist/cjs/isolated-container.js
@@ -12,7 +12,8 @@ exports["default"] = function isolatedContainer(fullNames) {
   container.register('component-lookup:main', Ember.ComponentLookup);
   for (var i = fullNames.length; i > 0; i--) {
     var fullName = fullNames[i - 1];
-    container.register(fullName, resolver.resolve(fullName));
+    var normalizedFullName = resolver.normalize(fullName);
+    container.register(fullName, resolver.resolve(normalizedFullName));
   }
   return container;
 }

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -13,7 +13,8 @@ exports["default"] = function isolatedContainer(fullNames) {
   container.register('component-lookup:main', Ember.ComponentLookup);
   for (var i = fullNames.length; i > 0; i--) {
     var fullName = fullNames[i - 1];
-    container.register(fullName, resolver.resolve(fullName));
+    var normalizedFullName = resolver.normalize(fullName);
+    container.register(fullName, resolver.resolve(normalizedFullName));
   }
   return container;
 }

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -15,7 +15,8 @@ define("ember-qunit/isolated-container",
       container.register('component-lookup:main', Ember.ComponentLookup);
       for (var i = fullNames.length; i > 0; i--) {
         var fullName = fullNames[i - 1];
-        container.register(fullName, resolver.resolve(fullName));
+        var normalizedFullName = resolver.normalize(fullName);
+        container.register(fullName, resolver.resolve(normalizedFullName));
       }
       return container;
     }

--- a/lib/isolated-container.js
+++ b/lib/isolated-container.js
@@ -11,7 +11,8 @@ export default function isolatedContainer(fullNames) {
   container.register('component-lookup:main', Ember.ComponentLookup);
   for (var i = fullNames.length; i > 0; i--) {
     var fullName = fullNames[i - 1];
-    container.register(fullName, resolver.resolve(fullName));
+    var normalizedFullName = resolver.normalize(fullName);
+    container.register(fullName, resolver.resolve(normalizedFullName));
   }
   return container;
 }

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -35,8 +35,9 @@ var registry = {
   'template:components/pretty-color': 'Pretty Color: <span class="color-name">{{name}}</span>'.compile(),
   'route:foo': Ember.Route.extend(),
   'controller:foos': Ember.ArrayController.extend(),
+  'controller:hello-world': Ember.ObjectController.extend(),
   'controller:bar': Ember.Controller.extend({
-    needs: ['foos']
+    needs: ['foos', 'helloWorld']
   }),
   'model:post': Post,
   'model:comment': Comment,
@@ -48,6 +49,9 @@ var registry = {
 var Resolver = Ember.DefaultResolver.extend({
   resolve: function(fullName) {
     return registry[fullName] || this._super.apply(this, arguments);
+  },
+  normalize: function(fullName) {
+    return Ember.String.dasherize(fullName);
   }
 });
 
@@ -74,27 +78,31 @@ setResolver(Resolver.create());
 //});
 
 moduleFor('controller:bar', 'moduleFor with bar controller', {
-  needs: ['controller:foos']
+  needs: ['controller:foos', 'controller:helloWorld']
 });
 
 test('exists', function() {
   var bar = this.subject();
 
   var foos = bar.get('controllers.foos');
+  var helloWorld = bar.get('controllers.helloWorld');
 
   ok(bar);
   ok(bar instanceof Ember.Controller);
   ok(foos instanceof Ember.ArrayController);
+  ok(helloWorld instanceof Ember.ObjectController);
 });
 
 test('exists again', function() {
   var bar = this.subject();
 
   var foos = bar.get('controllers.foos');
+  var helloWorld = bar.get('controllers.helloWorld');
 
   ok(bar);
   ok(bar instanceof Ember.Controller);
   ok(foos instanceof Ember.ArrayController);
+  ok(helloWorld instanceof Ember.ObjectController);
 });
 
 moduleForModel('whazzit', 'moduleForModel whazzit without adapter');


### PR DESCRIPTION
This caused an issue for us when using the ES6 resolver and entities with more than one name which are dasherized. Here's an example of something that was previously problematic:

```
moduleForComponent('tags-edit', 'Unit: Component tags-edit', {
  needs: [
    'controller:tagItem',
    'component:bc-text',
    'template:components/bc-text'
  ]
});
```

In this case, I was using an `itemController` for an `{{each}}` within my component. The each helper in my template will always try to look up the value as camel case (as is convention). However, because I'm using the ES 6 resolver, all names are dashized on the filesystem. So prior to this change, no attempt was made to allow the resolver to normalize the value before looking it up. IE there was no way for 'controller:tag-item' to be registered as 'controller:tagItem'.

I don't anticipate this being a breaking change, even for those using the ES6 resolver.
