### PR TITLE
Add a few more npm scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,7 @@ test this library.
 ### Installation
 
 ```sh
-$ npm install -g bower broccoli-cli
 $ npm install
-$ bower install
 ```
 
 ### Testing
@@ -183,18 +181,12 @@ $ bower install
 In order to test in the browser:
 
 ```sh
-$ broccoli serve
+$ npm start
 ```
 
 ... and then visit [http://localhost:4200/tests](http://localhost:4200/tests).
 
 In order to perform a CI test:
-
-```sh
-$ rm -rf build && BROCCOLI_ENV=test broccoli build build && testem ci
-```
-
-Or simply:
 
 ```sh
 $ npm test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "QUnit helpers for testing Ember.js applications",
   "main": "lib/ember-qunit.js",
   "scripts": {
-    "test": "rm -rf build && BROCCOLI_ENV=test broccoli build build && testem ci"
+    "build": "rm -rf build && BROCCOLI_ENV=test broccoli build build",
+    "prepublish": "bower install",
+    "pretest": "npm run-script build",
+    "test": "testem ci",
+    "start": "BROCCOLI_ENV=test broccoli serve"
   },
   "authors": [
     "Stefan Penner",
@@ -14,6 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "bower": "^1.3.12",
     "broccoli": "^0.13.0",
     "broccoli-concat": "^0.0.11",
     "broccoli-es6-concatenator": "^0.1.7",


### PR DESCRIPTION
- Add `npm run build` to generate the build.
- Add a `prepublish` script to ensure that bower packages are installed
  on `npm install` (but not from consumers).
- Add `npm start` to run `broccoli serve`.

/cc @dgeb
