### PR TITLE
Use emberjs org name instead of rwjblue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ember QUnit [![Build Status](https://travis-ci.org/rwjblue/ember-qunit.png)](https://travis-ci.org/rwjblue/ember-qunit)
+# Ember QUnit [![Build Status](https://travis-ci.org/emberjs/ember-qunit.png)](https://travis-ci.org/emberjs/ember-qunit)
 
 Ember QUnit simplifies unit testing of Ember applications with QUnit by
 providing QUnit-specific wrappers around the helpers contained in

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/rwjblue/ember-qunit.git"
+    "url": "https://github.com/emberjs/ember-qunit.git"
   }
 }


### PR DESCRIPTION
Just fixes the build status badge and the link to the CI 