### PR TITLE
Add 'phantomjs-prebuilt' to dev dependency in order to make test work locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "ember-cli-release": "^0.2.9",
     "exists-sync": "0.0.3",
     "git-repo-version": "^0.3.1",
+    "phantomjs-prebuilt": "^2.1.12",
     "resolve": "^1.1.7"
   },
   "repository": {


### PR DESCRIPTION
Without that the tests just doesn't run at all when running `ember test` locally

```
1..0
# tests 0
# pass  0
# fail  0
```
Probably it works on CI because phantom its installed globally.