### PR TITLE
Make Qunit module available as 'ember-qunit' export

### DIFF
--- a/lib/ember-qunit.js
+++ b/lib/ember-qunit.js
@@ -3,7 +3,7 @@ import moduleForComponent   from 'ember-qunit/module-for-component';
 import moduleForModel       from 'ember-qunit/module-for-model';
 import QUnitAdapter         from 'ember-qunit/adapter';
 import { setResolver }      from 'ember-test-helpers';
-export { test, skip, only } from 'qunit';
+export { module, test, skip, only } from 'qunit';
 
 export {
   moduleFor,


### PR DESCRIPTION
Just to be consistent with the other [other](https://github.com/emberjs/ember-qunit/blob/master/tests/qunit-shim-test.js) [parts](https://github.com/emberjs/ember-qunit/blob/master/lib/qunit.js) and because I think it's useful to be uses in tests like 

```javascript
import {module} from 'ember-qunit';

module('My custom class test...');
```
Instead of using `window.module` which doesn't work anymore or `QUnit.module`, also in some cases in which `moduleFor...` doesn't fit.