### PR TITLE
Update "ember-test-helpers" to v0.6.0-beta.1

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -25,7 +25,6 @@ var loader = new Funnel('bower_components', {
 });
 
 var emberTestHelpersPath = path.dirname(resolve.sync('ember-test-helpers'));
-var klassyPath = path.dirname(resolve.sync('klassy', { basedir: emberTestHelpersPath }));
 
 var emberTestHelpers = new Funnel(emberTestHelpersPath, {
   srcDir: '/',
@@ -33,13 +32,7 @@ var emberTestHelpers = new Funnel(emberTestHelpersPath, {
   destDir: '/'
 });
 
-// TODO - this manual dependency management has got to go!
-var klassy = new Funnel(klassyPath, {
-  srcDir: '/',
-  files: ['klassy.js'],
-  destDir: '/'
-});
-var deps = mergeTrees([klassy, emberTestHelpers]);
+var deps = mergeTrees([emberTestHelpers]);
 
 var lib = new Funnel('lib', {
   srcDir: '/',

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "ember-test-helpers": "^0.5.32"
+    "ember-test-helpers": "^0.6.0-beta.1"
   },
   "devDependencies": {
     "bower": "^1.3.12",


### PR DESCRIPTION
... and remove "klassy" (see https://github.com/emberjs/ember-test-helpers/pull/183)

This is unfortunately a breaking change (for ember-cli-qunit) and will require a major version bump.

/cc @rwjblue @trentmwillis 