### PR TITLE
Update adapter to use pushResult

### DIFF
--- a/lib/ember-qunit/adapter.js
+++ b/lib/ember-qunit/adapter.js
@@ -15,6 +15,9 @@ export default Ember.Test.Adapter.extend({
   },
 
   exception(error) {
-    QUnit.config.current.assert.ok(false, Ember.inspect(error));
+    QUnit.config.current.pushResult({
+      result: false,
+      message: Ember.inspect(error)
+    });
   }
 });


### PR DESCRIPTION
Currently there is a recursive error when an exception is thrown. This
happens when `findWithAssert` from Ember.Testing cannot find the given
selector.

From QUnit

`Test#pushFailure` calls `Assert#pushResult`
https://github.com/qunitjs/qunit/blob/master/src/test.js#L388

`Assert#pushResult` calls `Test#pushFailure`
https://github.com/qunitjs/qunit/blob/master/src/assert.js#L107

This leads to maximum call stack error in JS.

This PR fixes the issue by not using `assert.ok` when an exception
is thrown. Instead it uses pushResult to fail the test.