### PR TITLE
[WIP] New API Iteration

### DIFF
--- a/lib/ember-qunit.js
+++ b/lib/ember-qunit.js
@@ -2,13 +2,27 @@ import moduleFor            from 'ember-qunit/module-for';
 import moduleForComponent   from 'ember-qunit/module-for-component';
 import moduleForModel       from 'ember-qunit/module-for-model';
 import QUnitAdapter         from 'ember-qunit/adapter';
-import { setResolver }      from 'ember-test-helpers';
+import setupTestFactory     from 'ember-qunit/setup-test-factory';
+import {
+  setResolver,
+  TestModule,
+  TestModuleForIntegration,
+  TestModuleForAcceptance
+} from 'ember-test-helpers';
+
 export { module, test, skip, only, todo } from 'qunit';
+
+const setupTest = setupTestFactory(TestModule);
+const setupAcceptanceTest = setupTestFactory(TestModuleForAcceptance);
+const setupIntegrationTest = setupTestFactory(TestModuleForIntegration);
 
 export {
   moduleFor,
   moduleForComponent,
   moduleForModel,
+  setupTest,
+  setupAcceptanceTest,
+  setupIntegrationTest,
   setResolver,
   QUnitAdapter
 };

--- a/lib/ember-qunit.js
+++ b/lib/ember-qunit.js
@@ -3,6 +3,7 @@ import moduleForComponent   from 'ember-qunit/module-for-component';
 import moduleForModel       from 'ember-qunit/module-for-model';
 import QUnitAdapter         from 'ember-qunit/adapter';
 import setupTestFactory     from 'ember-qunit/setup-test-factory';
+import { buildOptionsWrapperFactory } from 'ember-qunit/qunit-module';
 import {
   setResolver,
   TestModule,
@@ -16,6 +17,11 @@ const setupTest = setupTestFactory(TestModule);
 const setupAcceptanceTest = setupTestFactory(TestModuleForAcceptance);
 const setupIntegrationTest = setupTestFactory(TestModuleForIntegration);
 
+
+const buildUnitOptions = buildOptionsWrapperFactory(TestModule);
+const buildIntegrationOptions = buildOptionsWrapperFactory(TestModuleForIntegration);
+const buildAcceptanceOptions = buildOptionsWrapperFactory(TestModuleForAcceptance);
+
 export {
   moduleFor,
   moduleForComponent,
@@ -23,6 +29,9 @@ export {
   setupTest,
   setupAcceptanceTest,
   setupIntegrationTest,
+  buildUnitOptions,
+  buildIntegrationOptions,
+  buildAcceptanceOptions,
   setResolver,
   QUnitAdapter
 };

--- a/lib/ember-qunit/qunit-module.js
+++ b/lib/ember-qunit/qunit-module.js
@@ -17,10 +17,12 @@ function callbackFor(name, callbacks) {
   return callback;
 }
 
-export function createModule(Constructor, name, description, callbacks) {
-  if (!callbacks && typeof description === 'object') {
-    callbacks = description;
-    description = name;
+export function wrapCallbacks(Constructor, _name, _callbacks) {
+  let callbacks = _callbacks;
+  let name = _name;
+  if (!callbacks) {
+    callbacks = name;
+    name = '';
   }
 
   var before = callbackFor('before', callbacks);
@@ -29,34 +31,66 @@ export function createModule(Constructor, name, description, callbacks) {
   var after  = callbackFor('after', callbacks);
 
   var module;
-  var moduleName = typeof description === 'string' ? description : name;
+  var options = {};
 
-  qunitModule(moduleName, {
-    before() {
-      // storing this in closure scope to avoid exposing these
-      // private internals to the test context
-      module = new Constructor(name, description, callbacks);
-      return before.apply(this, arguments);
-    },
-
-    beforeEach() {
-      // provide the test context to the underlying module
-      module.setContext(this);
-
-      return module.setup(...arguments).then(() => {
-        return beforeEach.apply(this, arguments);
-      });
-    },
-
-    afterEach() {
-      let result = afterEach.apply(this, arguments);
-      return Ember.RSVP.resolve(result).then(() => module.teardown(...arguments));
-    },
-
-    after() {
-      let result = after.apply(this, arguments);
-      module = null;
-      return result;
+  if (callbacks) {
+    for (let key in callbacks) {
+      options[key] = callbacks[key];
     }
-  });
+  }
+
+  options.before = function() {
+    module = new Constructor(name || '', callbacks);
+
+    if (before) {
+      return before.apply(this, arguments);
+    }
+  };
+
+  options.beforeEach = function() {
+    // provide the test context to the underlying module
+    module.setContext(this);
+
+    return module.setup(...arguments).then(() => {
+      if (beforeEach) {
+        return beforeEach.apply(this, arguments);
+      }
+    });
+  };
+
+  options.afterEach = function() {
+    let result;
+
+    if (afterEach) {
+      result = afterEach.apply(this, arguments);
+    }
+
+    return Ember.RSVP.resolve(result).then(() => module.teardown(...arguments));
+  };
+
+  options.after = function() {
+    let result;
+
+    if (before) {
+      result = after.apply(this, arguments);
+    }
+
+    module = null;
+
+    return result;
+  };
+
+  return options;
+}
+
+export function buildOptionsWrapperFactory(Constructor) {
+  return function optionsWrapperFactory(name, callbacks) {
+    return wrapCallbacks(Constructor, name, callbacks);
+  };
+}
+
+export function createModule(Constructor, name, description, callbacks) {
+  let options = wrapCallbacks(Constructor, name, callbacks || description);
+
+  qunitModule(name, options);
 }

--- a/lib/ember-qunit/qunit-module.js
+++ b/lib/ember-qunit/qunit-module.js
@@ -20,7 +20,7 @@ function callbackFor(name, callbacks) {
 export function wrapCallbacks(Constructor, _name, _callbacks) {
   let callbacks = _callbacks;
   let name = _name;
-  if (!callbacks) {
+  if (!callbacks && typeof name === 'object') {
     callbacks = name;
     name = '';
   }

--- a/lib/ember-qunit/setup-test-factory.js
+++ b/lib/ember-qunit/setup-test-factory.js
@@ -1,0 +1,24 @@
+export default function(Constructor) {
+  return function setupTest(hooks, options) {
+    let module;
+
+    hooks.before(function() {
+      // TODO: should we actually have this in the API
+      module = new Constructor('', options);
+    });
+
+    hooks.beforeEach(function() {
+      module.setContext(this);
+
+      return module.setup(...arguments);
+    });
+
+    hooks.afterEach(function() {
+      return module.teardown(...arguments);
+    });
+
+    hooks.after(function() {
+      module = null;
+    });
+  };
+}

--- a/tests/build-integration-options-test.js
+++ b/tests/build-integration-options-test.js
@@ -1,0 +1,17 @@
+/* global setTimeout */
+
+import Ember from 'ember';
+import { module, test, buildIntegrationOptions } from 'ember-qunit';
+import setupRegistry from './test-support/setup-registry';
+
+module('component:x-foo', buildIntegrationOptions({
+  before: setupRegistry
+}));
+
+test('renders', function(assert) {
+  assert.expect(1);
+
+  this.render(Ember.Handlebars.compile(`{{pretty-color name="red"}}`));
+
+  assert.equal(this.$('.color-name').text(), 'red');
+});

--- a/tests/setup-integration-test-test.js
+++ b/tests/setup-integration-test-test.js
@@ -2,30 +2,13 @@
 
 import Ember from 'ember';
 import { module, test, setupIntegrationTest } from 'ember-qunit';
-import { setResolverRegistry } from './test-support/resolver';
-
-var PrettyColor = Ember.Component.extend({
-  classNames: ['pretty-color'],
-  attributeBindings: ['style'],
-  style: function(){
-    return 'color: ' + this.get('name') + ';';
-  }.property('name')
-});
-
-function setupRegistry() {
-  setResolverRegistry({
-    'component:x-foo': Ember.Component.extend(),
-    'component:pretty-color': PrettyColor,
-    'template:components/pretty-color': Ember.Handlebars.compile('Pretty Color: <span class="color-name">{{name}}</span>')
-  });
-}
+import setupRegistry from './test-support/setup-registry';
 
 module('component:x-foo', function(hooks) {
-  hooks.before(setupRegistry);
-
   setupIntegrationTest(hooks);
 
   test('renders', function(assert) {
+    setupRegistry();
     assert.expect(1);
 
     this.render(Ember.Handlebars.compile(`{{pretty-color name="red"}}`));

--- a/tests/setup-integration-test-test.js
+++ b/tests/setup-integration-test-test.js
@@ -1,0 +1,35 @@
+/* global setTimeout */
+
+import Ember from 'ember';
+import { module, test, setupIntegrationTest } from 'ember-qunit';
+import { setResolverRegistry } from './test-support/resolver';
+
+var PrettyColor = Ember.Component.extend({
+  classNames: ['pretty-color'],
+  attributeBindings: ['style'],
+  style: function(){
+    return 'color: ' + this.get('name') + ';';
+  }.property('name')
+});
+
+function setupRegistry() {
+  setResolverRegistry({
+    'component:x-foo': Ember.Component.extend(),
+    'component:pretty-color': PrettyColor,
+    'template:components/pretty-color': Ember.Handlebars.compile('Pretty Color: <span class="color-name">{{name}}</span>')
+  });
+}
+
+module('component:x-foo', function(hooks) {
+  hooks.before(setupRegistry);
+
+  setupIntegrationTest(hooks);
+
+  test('renders', function(assert) {
+    assert.expect(1);
+
+    this.render(Ember.Handlebars.compile(`{{pretty-color name="red"}}`));
+
+    assert.equal(this.$('.color-name').text(), 'red');
+  });
+});

--- a/tests/test-support/setup-registry.js
+++ b/tests/test-support/setup-registry.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+import { setResolverRegistry } from './resolver';
+
+var PrettyColor = Ember.Component.extend({
+  classNames: ['pretty-color'],
+  attributeBindings: ['style'],
+  style: function(){
+    return 'color: ' + this.get('name') + ';';
+  }.property('name')
+});
+
+export default function setupRegistry() {
+  setResolverRegistry({
+    'component:x-foo': Ember.Component.extend(),
+    'component:pretty-color': PrettyColor,
+    'template:components/pretty-color': Ember.Handlebars.compile('Pretty Color: <span class="color-name">{{name}}</span>')
+  });
+}


### PR DESCRIPTION
This is an effort to reduce ember-qunit's surface area, and leave the "testing framework" work to QUnit. 

It is heavily inspired by the work that @Turbo87 did for ember-mocha (checkout their API [here](https://github.com/emberjs/ember-mocha/blob/master/README.md)).

Sample integration test with the new API:

```js
import { module, test } from 'qunit';
import { buildIntegrationOptions } from 'ember-qunit';

module('component:x-foo', buildIntegrationOptions({
  beforeEach() {
    // special setup stuff
  }
}));

test('renders', function(assert) {
  assert.expect(1);

  this.render(hbs`{{pretty-color name="red"}}`);

  assert.equal(this.$('.color-name').text(), 'red');
});
```

---

I've also added work to enable an even nicer API (IMHO of course) with nested modules, but that effort is blocked by https://github.com/qunitjs/qunit/issues/977.

The nested modules API would look like:

```js
import { module, test } from 'qunit';
import { setupIntegrationTest } from 'ember-qunit';

module('component:x-foo', function(hooks) {
  setupIntegrationTest(hooks);

  test('renders', function(assert) {
    setupRegistry();
    assert.expect(1);

    this.render(hbs`{{pretty-color name="red"}}`);

    assert.equal(this.$('.color-name').text(), 'red');
  });
});
```