### PR TITLE
Reset `module` variable after all tests in module are completed.

### DIFF
--- a/lib/ember-qunit/qunit-module.js
+++ b/lib/ember-qunit/qunit-module.js
@@ -43,11 +43,15 @@ export function createModule(Constructor, name, description, callbacks) {
   var beforeEach = beforeEachCallback(callbacks || description);
   var afterEach  = afterEachCallback(callbacks || description);
 
-  var module = new Constructor(name, description, callbacks);
+  var module;
 
-  qunitModule(module.name, {
+  qunitModule(name, {
     setup: function(assert) {
       var done = assert.async();
+
+      // storing this in closure scope to avoid exposing these
+      // private internals to the test context
+      module = new Constructor(name, description, callbacks);
 
       // provide the test context to the underlying module
       module.setContext(this);
@@ -67,7 +71,12 @@ export function createModule(Constructor, name, description, callbacks) {
       }
 
       var done = assert.async();
-      return Ember.RSVP.resolve(result).then(() => module.teardown()['finally'](done));
+      return Ember.RSVP.resolve(result)
+        .then(() => module.teardown())
+        .finally(() => {
+          module = null;
+          done();
+        });
     }
   });
 }


### PR DESCRIPTION
Backport of https://github.com/emberjs/ember-qunit/pull/260 to 0.4.x branch.