### PR TITLE
Revert "Reset `module` variable after all tests in module are completed."

### DIFF
--- a/lib/ember-qunit/qunit-module.js
+++ b/lib/ember-qunit/qunit-module.js
@@ -43,15 +43,11 @@ export function createModule(Constructor, name, description, callbacks) {
   var beforeEach = beforeEachCallback(callbacks || description);
   var afterEach  = afterEachCallback(callbacks || description);
 
-  var module;
+  var module = new Constructor(name, description, callbacks);
 
-  qunitModule(name, {
+  qunitModule(module.name, {
     setup: function(assert) {
       var done = assert.async();
-
-      // storing this in closure scope to avoid exposing these
-      // private internals to the test context
-      module = new Constructor(name, description, callbacks);
 
       // provide the test context to the underlying module
       module.setContext(this);
@@ -71,12 +67,7 @@ export function createModule(Constructor, name, description, callbacks) {
       }
 
       var done = assert.async();
-      return Ember.RSVP.resolve(result)
-        .then(() => module.teardown())
-        .finally(() => {
-          module = null;
-          done();
-        });
+      return Ember.RSVP.resolve(result).then(() => module.teardown()['finally'](done));
     }
   });
 }


### PR DESCRIPTION
This reverts commit fd38ea4439b88444fda97680f06e20e45dd49121.

So this actually broke some things due to weird shenanigans with how contexts get set up and passed around. The change was originally made to fix a memory leak, though after further investigation the memory leak appears to only affect qunit > 2.x, so we should just revert this change.