### PR TITLE
Properly call `setTestGenerator` method.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,12 @@ const stripIndent = require('common-tags').stripIndent;
 module.exports = {
   name: 'ember-qunit',
 
+  init() {
+    this._super.init && this._super.init.apply(this, arguments);
+
+    this.setTestGenerator();
+  },
+
   included() {
     this._super.included.apply(this, arguments);
 


### PR DESCRIPTION
This should have always been called from `init`, can't believe I missed this. 😱

Fixes https://github.com/ember-cli/ember-cli/issues/7374.