### PR TITLE
Update ember-test-helpers to expose `pauseTest` / `resumeTest`

### DIFF
--- a/addon-test-support/ember-qunit/index.js
+++ b/addon-test-support/ember-qunit/index.js
@@ -2,7 +2,14 @@ export { default as moduleFor } from './legacy-2-x/module-for';
 export { default as moduleForComponent } from './legacy-2-x/module-for-component';
 export { default as moduleForModel } from './legacy-2-x/module-for-model';
 export { default as QUnitAdapter } from './adapter';
-export { setResolver, render, clearRender, settled } from 'ember-test-helpers';
+export {
+  setResolver,
+  render,
+  clearRender,
+  settled,
+  pauseTest,
+  resumeTest,
+} from 'ember-test-helpers';
 export { module, test, skip, only, todo } from 'qunit';
 export { loadTests } from './test-loader';
 
@@ -18,8 +25,15 @@ import {
 } from 'ember-test-helpers';
 
 export function setupTest(hooks, options) {
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function(assert) {
     setupContext(this, options);
+
+    let originalPauseTest = this.pauseTest;
+    this.pauseTest = function QUnit_pauseTest() {
+      assert.timeout(-1); // prevent the test from timing out
+
+      return originalPauseTest.call(this);
+    };
   });
 
   hooks.afterEach(function() {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "common-tags": "^1.4.0",
     "ember-cli-babel": "^6.3.0",
     "ember-cli-test-loader": "^2.2.0",
-    "ember-test-helpers": "^0.7.0-beta.7",
+    "ember-test-helpers": "^0.7.0-beta.9",
     "qunitjs": "^2.4.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2133,9 +2133,9 @@ ember-source@~2.15.0:
     simple-dom "^0.3.0"
     simple-html-tokenizer "^0.4.1"
 
-ember-test-helpers@^0.7.0-beta.7:
-  version "0.7.0-beta.7"
-  resolved "https://registry.yarnpkg.com/ember-test-helpers/-/ember-test-helpers-0.7.0-beta.7.tgz#7a8d594af90875e2fc75ff0face5494d27b68446"
+ember-test-helpers@^0.7.0-beta.9:
+  version "0.7.0-beta.9"
+  resolved "https://registry.yarnpkg.com/ember-test-helpers/-/ember-test-helpers-0.7.0-beta.9.tgz#f1272d78821d988946d3d25dcf2cac81d3e79918"
   dependencies:
     broccoli-funnel "^2.0.1"
     ember-cli-babel "^6.8.1"


### PR DESCRIPTION
* Update to v0.7.0-beta.9
* Re-export the importable helpers `resumeTest` and `pauseTest`
* Wrap `this.pauseTest` to properly reset the test timeout (to avoid the
  test from being marked as failed due to timing out while interacting).

Fixes https://github.com/emberjs/ember-qunit/issues/287