### PR TITLE
Migrate from `qunitjs` to `qunit` package.

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = {
   treeForVendor: function(tree) {
     const MergeTrees = require('broccoli-merge-trees');
     const Funnel = require('broccoli-funnel');
-    let qunitPath = path.dirname(require.resolve('qunitjs'));
+    let qunitPath = path.dirname(require.resolve('qunit'));
 
     let qunitTree = new Funnel(this.treeGenerator(qunitPath), {
       destDir: 'qunit',

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ember-cli-babel": "^6.3.0",
     "ember-cli-test-loader": "^2.2.0",
     "ember-test-helpers": "^0.7.0-beta.10",
-    "qunitjs": "^2.4.0"
+    "qunit": "^2.4.1"
   },
   "devDependencies": {
     "ember-cli": "~2.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4385,9 +4385,9 @@ quick-temp@^0.1.0, quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quic
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
 
-qunitjs@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/qunitjs/-/qunitjs-2.4.0.tgz#58f3a81e846687f2e7f637c5bedc9c267f887261"
+qunit@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.4.1.tgz#373c826b3b91795f3e5479cc94f0f6fa14dedc47"
   dependencies:
     chokidar "1.6.1"
     commander "2.9.0"


### PR DESCRIPTION
The `qunitjs` package has been deprecated in favor of the `qunit` package (since `qunit` is the more obvious package name).

This updates to the new package (which is functionally identical).

See https://github.com/qunitjs/qunit/pull/1232 for more details.