### PR TITLE
CI: Use Node 4 for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "6"
+  - "4"
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.15.0",
     "eslint-config-prettier": "^2.6.0",
-    "eslint-plugin-disable-features": "^0.1.2",
+    "eslint-plugin-disable-features": "^0.1.3",
     "eslint-plugin-prettier": "^2.3.1",
     "loader.js": "^4.2.3",
     "prettier": "^1.7.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2288,9 +2288,9 @@ eslint-config-prettier@^2.6.0:
   dependencies:
     get-stdin "^5.0.1"
 
-eslint-plugin-disable-features@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-disable-features/-/eslint-plugin-disable-features-0.1.2.tgz#a5e53dd61e517d897938b8451bce13b24677597f"
+eslint-plugin-disable-features@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-disable-features/-/eslint-plugin-disable-features-0.1.3.tgz#f093418c860d7be41ed46519eedf3f70eb7e29f2"
   dependencies:
     requireindex "~1.1.0"
 


### PR DESCRIPTION
This PR reverts https://github.com/emberjs/ember-qunit/commit/b9db3fd6f811f69e9e9a62f0926abd05f2d670f1 as https://github.com/brendenpalmer/eslint-plugin-disable-features/pull/6 has been merged and released.