### PR TITLE
Implement `startApplicationTest` from emberjs/rfcs#268.

### DIFF
--- a/addon-test-support/ember-qunit/index.js
+++ b/addon-test-support/ember-qunit/index.js
@@ -15,6 +15,8 @@ import {
   teardownContext,
   setupRenderingContext,
   teardownRenderingContext,
+  setupApplicationContext,
+  teardownApplicationContext,
 } from '@ember/test-helpers';
 
 export function setupTest(hooks, options) {
@@ -43,6 +45,18 @@ export function setupRenderingTest(hooks, options) {
 
   hooks.afterEach(function() {
     return teardownRenderingContext(this);
+  });
+}
+
+export function setupApplicationTest(hooks, options) {
+  setupTest(hooks, options);
+
+  hooks.beforeEach(function() {
+    return setupApplicationContext(this);
+  });
+
+  hooks.afterEach(function() {
+    return teardownApplicationContext(this);
   });
 }
 

--- a/addon-test-support/ember-qunit/index.js
+++ b/addon-test-support/ember-qunit/index.js
@@ -2,14 +2,7 @@ export { default as moduleFor } from './legacy-2-x/module-for';
 export { default as moduleForComponent } from './legacy-2-x/module-for-component';
 export { default as moduleForModel } from './legacy-2-x/module-for-model';
 export { default as QUnitAdapter } from './adapter';
-export {
-  setResolver,
-  render,
-  clearRender,
-  settled,
-  pauseTest,
-  resumeTest,
-} from '@ember/test-helpers';
+export { setResolver } from '@ember/test-helpers';
 export { module, test, skip, only, todo } from 'qunit';
 export { loadTests } from './test-loader';
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "@ember/test-helpers": "^0.7.1",
+    "@ember/test-helpers": "^0.7.9",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",
     "common-tags": "^1.4.0",

--- a/tests/acceptance/basic-test.js
+++ b/tests/acceptance/basic-test.js
@@ -1,0 +1,102 @@
+import { module, test } from 'qunit';
+import EmberRouter from '@ember/routing/router';
+import Route from '@ember/routing/route';
+import hbs from 'htmlbars-inline-precompile';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit, currentRouteName, currentURL, click } from '@ember/test-helpers';
+import { setResolverRegistry } from '../helpers/resolver';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+
+module('setupApplicationTest tests', function(hooks) {
+  if (!hasEmberVersion(2, 4)) {
+    return;
+  }
+
+  const Router = EmberRouter.extend({ location: 'none' });
+  Router.map(function() {
+    this.route('widgets');
+    this.route('posts', function() {
+      this.route('post', { path: ':post_id' });
+    });
+  });
+
+  hooks.beforeEach(function() {
+    setResolverRegistry({
+      'router:main': Router,
+      'template:application': hbs`
+        <div class="nav">{{link-to 'posts' 'posts'}} | {{link-to 'widgets' 'widgets'}}</div>
+        {{outlet}}
+      `,
+      'template:index': hbs`<h1>Hello World!</h1>`,
+      'template:posts': hbs`<h1>Posts Page</h1>{{outlet}}`,
+      'template:posts/post': hbs`<div class="post-id">{{model.post_id}}</div>`,
+      'route:posts/post': Route.extend({
+        model(params) {
+          return params;
+        },
+      }),
+    });
+  });
+
+  setupApplicationTest(hooks);
+
+  test('can render', async function(assert) {
+    await visit('/');
+
+    assert.equal(currentRouteName(), 'index');
+    assert.equal(currentURL(), '/');
+
+    assert.equal(this.element.querySelector('.nav').textContent, 'posts | widgets');
+    assert.equal(this.element.querySelector('h1').textContent, 'Hello World!');
+  });
+
+  test('can perform a basic template rendering for nested route', async function(assert) {
+    await visit('/posts/1');
+
+    assert.equal(currentRouteName(), 'posts.post');
+    assert.equal(currentURL(), '/posts/1');
+
+    assert.equal(this.element.querySelector('.nav').textContent, 'posts | widgets');
+    assert.equal(this.element.querySelector('.post-id').textContent, '1');
+  });
+
+  test('can visit multiple times', async function(assert) {
+    await visit('/posts/1');
+
+    assert.equal(currentRouteName(), 'posts.post');
+    assert.equal(currentURL(), '/posts/1');
+
+    assert.equal(this.element.querySelector('.nav').textContent, 'posts | widgets');
+    assert.equal(this.element.querySelector('.post-id').textContent, '1');
+
+    await visit('/');
+
+    assert.equal(currentRouteName(), 'index');
+    assert.equal(currentURL(), '/');
+
+    assert.equal(this.element.querySelector('.nav').textContent, 'posts | widgets');
+    assert.equal(this.element.querySelector('h1').textContent, 'Hello World!');
+
+    await visit('/posts/2');
+
+    assert.equal(currentRouteName(), 'posts.post');
+    assert.equal(currentURL(), '/posts/2');
+
+    assert.equal(this.element.querySelector('.nav').textContent, 'posts | widgets');
+    assert.equal(this.element.querySelector('.post-id').textContent, '2');
+  });
+
+  test('can navigate amongst routes', async function(assert) {
+    await visit('/');
+
+    assert.equal(currentRouteName(), 'index');
+    assert.equal(currentURL(), '/');
+
+    await click('a[href="/posts"]');
+
+    assert.equal(currentRouteName(), 'posts.index');
+    assert.equal(currentURL(), '/posts');
+
+    assert.equal(this.element.querySelector('h1').textContent, 'Posts Page');
+  });
+});

--- a/tests/dummy/app/resolver.js
+++ b/tests/dummy/app/resolver.js
@@ -1,3 +1,12 @@
 import Resolver from 'ember-resolver';
 
-export default Resolver;
+export let registry = Object.create(null);
+export function setRegistry(newRegistry) {
+  registry = newRegistry;
+}
+
+export default Resolver.extend({
+  resolve(fullName) {
+    return registry[fullName] || this._super(...arguments);
+  },
+});

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -41,6 +41,7 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     ENV.APP.rootElement = '#ember-testing';
+    ENV.APP.autoboot = false;
   }
 
   return ENV;

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,28 +1,18 @@
-import Ember from 'ember';
-import AppResolver from '../../resolver';
+import App from '../../app';
+import { setRegistry } from '../../resolver';
 import config from '../../config/environment';
 import { setResolver } from 'ember-test-helpers';
 
-const Resolver = AppResolver.extend({
-  resolve: function(fullName) {
-    return this.registry[fullName] || this._super.apply(this, arguments);
-  },
-
-  normalize: function(fullName) {
-    return Ember.String.dasherize(fullName);
-  },
+export const application = App.create(config.APP);
+export const resolver = application.Resolver.create({
+  namespace: application,
+  isResolverFromTestHelpers: true,
 });
-const resolver = Resolver.create();
-
-resolver.namespace = {
-  modulePrefix: config.modulePrefix,
-  podModulePrefix: config.podModulePrefix,
-};
 
 export default resolver;
 
 setResolver(resolver);
 
 export function setResolverRegistry(registry) {
-  resolver.set('registry', registry);
+  setRegistry(registry);
 }

--- a/tests/integration/setup-rendering-test-test.js
+++ b/tests/integration/setup-rendering-test-test.js
@@ -2,7 +2,8 @@ import { module, test } from 'qunit';
 import Component from '@ember/component';
 import { helper } from '@ember/component/helper';
 import hbs from 'htmlbars-inline-precompile';
-import { setupRenderingTest, render } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import { setResolverRegistry } from '../helpers/resolver';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,5 +1,6 @@
-import resolver from './helpers/resolver';
-import { setResolver, start } from 'ember-qunit';
+import { application } from './helpers/resolver';
+import { start } from 'ember-qunit';
+import { setApplication } from '@ember/test-helpers';
 
-setResolver(resolver);
+setApplication(application);
 start();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,12 @@
 # yarn lockfile v1
 
 
-"@ember/test-helpers@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-0.7.1.tgz#14ba828ebc5b7b0e6eb7889352cb40af0c995349"
+"@ember/test-helpers@^0.7.9":
+  version "0.7.9"
+  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-0.7.9.tgz#97d06e077a70028ca8e7a11ede7e8725e1a53167"
   dependencies:
     broccoli-funnel "^2.0.1"
-    ember-cli-babel "^6.8.1"
+    ember-cli-babel "^6.10.0"
 
 "@glimmer/compiler@^0.25.3":
   version "0.25.3"
@@ -516,6 +516,12 @@ babel-plugin-debug-macros@^0.1.10, babel-plugin-debug-macros@^0.1.11:
 babel-plugin-ember-modules-api-polyfill@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.1.0.tgz#78848cc4fcc2274882a6c15cbb23fefcdc771301"
+  dependencies:
+    ember-rfc176-data "^0.3.0"
+
+babel-plugin-ember-modules-api-polyfill@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz#0c01f359658cfb9c797f705af6b09f6220205ae0"
   dependencies:
     ember-rfc176-data "^0.3.0"
 
@@ -1791,6 +1797,24 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.3.0, e
     broccoli-source "^1.1.0"
     clone "^2.0.0"
     ember-cli-version-checker "^2.0.0"
+
+ember-cli-babel@^6.10.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.11.0.tgz#79cb184bac3c05bfe181ddc306bac100ab1f9493"
+  dependencies:
+    amd-name-resolver "0.0.7"
+    babel-plugin-debug-macros "^0.1.11"
+    babel-plugin-ember-modules-api-polyfill "^2.3.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.5.1"
+    broccoli-babel-transpiler "^6.1.2"
+    broccoli-debug "^0.6.2"
+    broccoli-funnel "^1.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.0"
+    semver "^5.4.1"
 
 ember-cli-broccoli-sane-watcher@^2.0.4:
   version "2.0.4"
@@ -4697,7 +4721,7 @@ sane@^1.1.1, sane@^1.6.0:
     walker "~1.0.5"
     watch "~0.10.0"
 
-semver@^5.1.0, semver@^5.1.1, semver@^5.3.0:
+semver@^5.1.0, semver@^5.1.1, semver@^5.3.0, semver@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 


### PR DESCRIPTION
Implements the `startApplicationTest` API proposed by https://github.com/emberjs/rfcs/pull/268.