### PR TITLE
Ensure Ember.testing is set properly during *ALL* tests.

### DIFF
--- a/addon-test-support/ember-qunit/index.js
+++ b/addon-test-support/ember-qunit/index.js
@@ -112,6 +112,22 @@ export function setupTestAdapter() {
 }
 
 /**
+  Ensures that `Ember.testing` is set to `true` before each test begins
+  (including `before` / `beforeEach`), and reset to `false` after each test is
+  completed. This is done via `QUnit.testStart` and `QUnit.testDone`.
+
+ */
+export function setupEmberTesting() {
+  QUnit.testStart(() => {
+    Ember.testing = true;
+  });
+
+  QUnit.testDone(() => {
+    Ember.testing = false;
+  });
+}
+
+/**
    @method start
    @param {Object} [options] Options to be used for enabling/disabling behaviors
    @param {Boolean} [options.loadTests] If `false` tests will not be loaded automatically.
@@ -121,6 +137,9 @@ export function setupTestAdapter() {
    (you must run `QUnit.start()` to kick them off).
    @param {Boolean} [options.setupTestAdapter] If `false` the default Ember.Test adapter will
    not be updated.
+   @param {Boolean} [options.setupEmberTesting] `false` opts out of the
+   default behavior of setting `Ember.testing` to `true` before all tests and
+   back to `false` after each test will.
  */
 export function start(options = {}) {
   if (options.loadTests !== false) {
@@ -133,6 +152,10 @@ export function start(options = {}) {
 
   if (options.setupTestAdapter !== false) {
     setupTestAdapter();
+  }
+
+  if (options.setupEmberTesting !== false) {
+    setupEmberTesting();
   }
 
   if (options.startTests !== false) {

--- a/tests/unit/ember-testing-test.js
+++ b/tests/unit/ember-testing-test.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+
+module('setupEmberTesting', function() {
+  test('Ember.testing is true in all test contexts', function(assert) {
+    assert.strictEqual(Ember.testing, true);
+  });
+});


### PR DESCRIPTION
Prior to this change `Ember.testing` was only set to `true` for `moduleForComponent` / `moduleFor` / `moduleForAcceptance` tests.  This meant that any "plain" tests were ran without `Ember.testing === true`. This breaks things like the `wait` / `settled` helpers, prevents assertions that _should_ happen from happening, etc.

This change ensures that (by default) `Ember.testing` is properly setup before each test and cleared after each test, but also offers an escape hatch for folks who actually do not want this behavior...

Fixes https://github.com/emberjs/ember-qunit/issues/297.