### PR TITLE
Add validation for Ember.onerror in testing.

### DIFF
--- a/addon-test-support/ember-qunit/index.js
+++ b/addon-test-support/ember-qunit/index.js
@@ -17,6 +17,7 @@ import {
   teardownRenderingContext,
   setupApplicationContext,
   teardownApplicationContext,
+  validateErrorHandler,
 } from '@ember/test-helpers';
 
 export function setupTest(hooks, options) {
@@ -128,6 +129,22 @@ export function setupEmberTesting() {
 }
 
 /**
+  Ensures that `Ember.onerror` (if present) is properly configured to re-throw
+  errors that occur while `Ember.testing` is `true`.
+*/
+export function setupEmberOnerrorValidation() {
+  QUnit.module('ember-qunit: Ember.onerror validation', function() {
+    QUnit.test('Ember.onerror is functioning properly', function(assert) {
+      let result = validateErrorHandler();
+      assert.ok(
+        result.isValid,
+        `Ember.onerror handler with invalid testing behavior detected. An Ember.onerror handler _must_ rethrow exceptions when \`Ember.testing\` is \`true\` or the test suite is unreliable. See https://git.io/vbine for more details.`
+      );
+    });
+  });
+}
+
+/**
    @method start
    @param {Object} [options] Options to be used for enabling/disabling behaviors
    @param {Boolean} [options.loadTests] If `false` tests will not be loaded automatically.
@@ -140,6 +157,8 @@ export function setupEmberTesting() {
    @param {Boolean} [options.setupEmberTesting] `false` opts out of the
    default behavior of setting `Ember.testing` to `true` before all tests and
    back to `false` after each test will.
+   @param {Boolean} [options.setupEmberOnerrorValidation] If `false` validation
+   of `Ember.onerror` will be disabled.
  */
 export function start(options = {}) {
   if (options.loadTests !== false) {
@@ -156,6 +175,10 @@ export function start(options = {}) {
 
   if (options.setupEmberTesting !== false) {
     setupEmberTesting();
+  }
+
+  if (options.setupEmberOnerrorValidation !== false) {
+    setupEmberOnerrorValidation();
   }
 
   if (options.startTests !== false) {

--- a/tests/unit/setup-ember-onerror-validation-test.js
+++ b/tests/unit/setup-ember-onerror-validation-test.js
@@ -1,0 +1,26 @@
+import Ember from 'ember';
+import { module } from 'qunit';
+import { setupEmberOnerrorValidation } from 'ember-qunit';
+
+module('setupEmberOnerrorValidation', function(hooks) {
+  hooks.beforeEach(function(assert) {
+    let originalPushResult = assert.pushResult;
+    assert.pushResult = function(resultInfo) {
+      // Inverts the result so we can test failing assertions
+      resultInfo.result = !resultInfo.result;
+      resultInfo.message = `Failed: ${resultInfo.message}`;
+      originalPushResult(resultInfo);
+    };
+
+    this.originalEmberOnerror = Ember.onerror;
+    Ember.onerror = function() {
+      // intentionally swallowing here
+    };
+  });
+
+  hooks.afterEach(function() {
+    Ember.onerror = this.originalEmberOnerror;
+  });
+
+  setupEmberOnerrorValidation();
+});


### PR DESCRIPTION
`Ember.onerror` intentionally is allowed to swallow errors, this is a very useful tool when in production to ensure that your application can be a tad bit more resilient to things like network issues and whatnot.

However, having an improperly configured `Ember.onerror` can lead to severe issues where your tests are passing but things in reality are completely broken.

This change leverages the `validateErrorHandler` utility function added in https://github.com/emberjs/ember-test-helpers/pull/247 to automatically add a test that will fail if `Ember.onerror` does not rethrow the error it is provided. Importantly, this new test adding behavior is on by default (in order to help folks that are unaware they are in a broken state), but can easily be disabled (see below for details).

### Example of Valid Ember.onerror

An example of a properly setup `Ember.onerror` is the following:

```js
// app/app.js
import Ember from 'ember';

Ember.onerror = function(error) {
  if (Ember.testing) {
    throw error;
  }

  // ...desired development and production behaviors here...
};
```

### Testing Production-like Behavior

In many cases, you will _actually_ want to test that the swallowing does occur and the app is able to recover (e.g. in an acceptance test that intentionally rejects one of your network requests).  To make that scenario easier to handle, we have created [ember-test-friendly-error-handler](https://github.com/rwjblue/ember-test-friendly-error-handler) which exposes a very simple API to allow specific tests to opt-in to the "production" behavior.  That might look like:

```js
// app/app.js
import Ember from 'ember';
import buildErrorHandler from 'ember-test-friendly-error-handler';

Ember.onerror = buildErrorHandler('Ember.onerror', (reason) => {
  reportErrorToService(reason);
  // whatever else you might want here...
});
```

```js
// test/acceptance/something-test.js
import { module, test } from 'qunit';
import { setupApplicationTest } from 'ember-qunit';
import { visit } from '@ember/test-helpers';
import { 
  squelchErrorHandlerFor,
  unsquelchAllErrorHandlers
} from 'ember-test-friendly-error-handler';

module('some good description', function(hooks) {
  setupApplicationTest(hooks);

  hooks.afterEach(() => {
    unsquelchAllErrorHandlers();
  });

  test('network failure message is displayed', async function(assert) {
    squelchErrorHandlerFor('Ember.onerror');
    
    await visit('/some-route-here');
    
    // assert things here...
  });
});
```

### Opting Out of Validation

In general, this is a bad idea. The validation exists specifically to protect applications from completely invalid test suites. 

If however, you have good reason to disable validation you can opt-out by setting the `setupEmberOnerrorValidation` option when calling `ember-qunit`'s `start()` method in `tests/test-helper.js`:

```js
import Application from '../app';
import { setApplication } from '@ember/test-helpers';
import { start } from 'ember-qunit';

setApplication(Application.create({ autoboot: false }));

start({ setupEmberOnerrorValidation: false });
```