### PR TITLE
Bring back re-exports (with a deprecation).

### DIFF
--- a/addon-test-support/ember-qunit/index.js
+++ b/addon-test-support/ember-qunit/index.js
@@ -2,22 +2,21 @@ export { default as moduleFor } from './legacy-2-x/module-for';
 export { default as moduleForComponent } from './legacy-2-x/module-for-component';
 export { default as moduleForModel } from './legacy-2-x/module-for-model';
 export { default as QUnitAdapter } from './adapter';
-export {
-  setResolver,
-  render,
-  clearRender,
-  settled,
-  pauseTest,
-  resumeTest,
-} from '@ember/test-helpers';
 export { module, test, skip, only, todo } from 'qunit';
 export { loadTests } from './test-loader';
 
+import { deprecate } from '@ember/debug';
 import { loadTests } from './test-loader';
 import Ember from 'ember';
 import QUnit from 'qunit';
 import QUnitAdapter from './adapter';
 import {
+  setResolver as upstreamSetResolver,
+  render as upstreamRender,
+  clearRender as upstreamClearRender,
+  settled as upstreamSettled,
+  pauseTest as upstreamPauseTest,
+  resumeTest as upstreamResumeTest,
   setupContext,
   teardownContext,
   setupRenderingContext,
@@ -25,6 +24,78 @@ import {
   setupApplicationContext,
   teardownApplicationContext,
 } from '@ember/test-helpers';
+
+export function setResolver() {
+  deprecate(
+    '`setResolver` should be imported from `@ember/test-helpers`, but was imported from `ember-qunit`',
+    {
+      id: 'ember-qunit.deprecated-reexports.setResolver',
+      until: '4.0.0',
+    }
+  );
+
+  return upstreamSetResolver(...arguments);
+}
+
+export function render() {
+  deprecate(
+    '`render` should be imported from `@ember/test-helpers`, but was imported from `ember-qunit`',
+    {
+      id: 'ember-qunit.deprecated-reexports.render',
+      until: '4.0.0',
+    }
+  );
+
+  return upstreamRender(...arguments);
+}
+
+export function clearRender() {
+  deprecate(
+    '`clearRender` should be imported from `@ember/test-helpers`, but was imported from `ember-qunit`',
+    {
+      id: 'ember-qunit.deprecated-reexports.clearRender',
+      until: '4.0.0',
+    }
+  );
+
+  return upstreamClearRender(...arguments);
+}
+
+export function settled() {
+  deprecate(
+    '`settled` should be imported from `@ember/test-helpers`, but was imported from `ember-qunit`',
+    {
+      id: 'ember-qunit.deprecated-reexports.settled',
+      until: '4.0.0',
+    }
+  );
+
+  return upstreamSettled(...arguments);
+}
+
+export function pauseTest() {
+  deprecate(
+    '`pauseTest` should be imported from `@ember/test-helpers`, but was imported from `ember-qunit`',
+    {
+      id: 'ember-qunit.deprecated-reexports.pauseTest',
+      until: '4.0.0',
+    }
+  );
+
+  return upstreamPauseTest(...arguments);
+}
+
+export function resumeTest() {
+  deprecate(
+    '`resumeTest` should be imported from `@ember/test-helpers`, but was imported from `ember-qunit`',
+    {
+      id: 'ember-qunit.deprecated-reexports.resumeTest',
+      until: '4.0.0',
+    }
+  );
+
+  return upstreamResumeTest(...arguments);
+}
 
 export function setupTest(hooks, options) {
   hooks.beforeEach(function(assert) {

--- a/addon-test-support/ember-qunit/index.js
+++ b/addon-test-support/ember-qunit/index.js
@@ -2,7 +2,14 @@ export { default as moduleFor } from './legacy-2-x/module-for';
 export { default as moduleForComponent } from './legacy-2-x/module-for-component';
 export { default as moduleForModel } from './legacy-2-x/module-for-model';
 export { default as QUnitAdapter } from './adapter';
-export { setResolver } from '@ember/test-helpers';
+export {
+  setResolver,
+  render,
+  clearRender,
+  settled,
+  pauseTest,
+  resumeTest,
+} from '@ember/test-helpers';
 export { module, test, skip, only, todo } from 'qunit';
 export { loadTests } from './test-loader';
 

--- a/tests/integration/setup-rendering-test-test.js
+++ b/tests/integration/setup-rendering-test-test.js
@@ -2,7 +2,8 @@ import { module, test } from 'qunit';
 import Component from '@ember/component';
 import { helper } from '@ember/component/helper';
 import hbs from 'htmlbars-inline-precompile';
-import { setupRenderingTest, render } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import { setResolverRegistry } from '../helpers/resolver';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 

--- a/tests/integration/setup-rendering-test-test.js
+++ b/tests/integration/setup-rendering-test-test.js
@@ -2,8 +2,7 @@ import { module, test } from 'qunit';
 import Component from '@ember/component';
 import { helper } from '@ember/component/helper';
 import hbs from 'htmlbars-inline-precompile';
-import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { setupRenderingTest, render } from 'ember-qunit';
 import { setResolverRegistry } from '../helpers/resolver';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 


### PR DESCRIPTION
The changes made in 05ac8233 should not have happened (its obviously a semver breaking change, done within a minor release). This reverts that change by bringing back the re-exports with a deprecation if they are used.

/cc @turbo87 @cibernox