### PR TITLE
Remove `exception` method from QUnit test adapter.

### DIFF
--- a/addon-test-support/ember-qunit/adapter.js
+++ b/addon-test-support/ember-qunit/adapter.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import QUnit from 'qunit';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 function unhandledRejectionAssertion(current, error) {
   let message, source;
@@ -24,7 +25,7 @@ function unhandledRejectionAssertion(current, error) {
   });
 }
 
-export default Ember.Test.Adapter.extend({
+let Adapter = Ember.Test.Adapter.extend({
   init() {
     this.doneCallbacks = [];
   },
@@ -40,8 +41,18 @@ export default Ember.Test.Adapter.extend({
       done();
     }
   },
-
-  exception(error) {
-    unhandledRejectionAssertion(QUnit.config.current, error);
-  },
 });
+
+// Ember 2.17 and higher do not require the test adapter to have an `exception`
+// method When `exception` is not present, the unhandled rejection is
+// automatically re-thrown and will therefore hit QUnit's own global error
+// handler (therefore appropriately causing test failure)
+if (!hasEmberVersion(2, 17)) {
+  Adapter = Adapter.extend({
+    exception(error) {
+      unhandledRejectionAssertion(QUnit.config.current, error);
+    },
+  });
+}
+
+export default Adapter;


### PR DESCRIPTION
As of Ember 2.17 the `Ember.Test.adapter` is not required to have an `exception` method, and the method essentially has no purpose. The default implementation (in the `Ember.Test.QUnitAdapter`) is to re-throw, but that is _exactly_ what happens by default.

This removes "yet another magical testing thing", and relies on both Ember and QUnit's default behaviors to ensure that tests properly fail when unhandled RSVP rejections occur.

Cross linking (again) https://github.com/emberjs/ember.js/pull/15871.

Should probably wait for the tests added around unhandled rejections in #306.