### PR TITLE
Add assert.expect to Ember.onerror validation test

### DIFF
--- a/addon-test-support/ember-qunit/index.js
+++ b/addon-test-support/ember-qunit/index.js
@@ -219,6 +219,7 @@ export function setupEmberTesting() {
 export function setupEmberOnerrorValidation() {
   QUnit.module('ember-qunit: Ember.onerror validation', function() {
     QUnit.test('Ember.onerror is functioning properly', function(assert) {
+      assert.expect(1);
       let result = validateErrorHandler();
       assert.ok(
         result.isValid,


### PR DESCRIPTION
For projects that enforce `QUnit.config.requireExpects`, the Ember.onerror validation test causes tests to fail.

This PR:
* Adds an `assert.expects(1)` statement.
* Passes all existing tests.