### PR TITLE
Update @ember/test-helpers minimum version to 0.7.18.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "@ember/test-helpers": "^0.7.17",
+    "@ember/test-helpers": "^0.7.18",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",
     "common-tags": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@ember/test-helpers@^0.7.17":
-  version "0.7.17"
-  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-0.7.17.tgz#17ff5f1d005d8b6331585e99013d66626a8d8068"
+"@ember/test-helpers@^0.7.18":
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-0.7.18.tgz#a0c474c3029588ec46d2e406252fc072b7f9aa3c"
   dependencies:
     broccoli-funnel "^2.0.1"
     ember-cli-babel "^6.10.0"


### PR DESCRIPTION
Fixes a gnarly issue with a refactor in 0.7.17's `wait` refactor.