### PR TITLE
Support running tests in the production environment where Ember.Test i…

### DIFF
--- a/addon-test-support/ember-qunit/adapter.js
+++ b/addon-test-support/ember-qunit/adapter.js
@@ -25,7 +25,11 @@ function unhandledRejectionAssertion(current, error) {
   });
 }
 
-let Adapter = Ember.Test.Adapter.extend({
+// libraries like ember-qunit-assert-helper may try to extend the
+// QUnitAdapter in when tests are run in production enviroments so
+// lets give them something to extend even when Ember.Test is
+// undefined.
+let Adapter = (Ember.Test ? Ember.Test.Adapter : Ember.Object).extend({
   init() {
     this.doneCallbacks = [];
   },

--- a/addon-test-support/ember-qunit/index.js
+++ b/addon-test-support/ember-qunit/index.js
@@ -202,7 +202,11 @@ export function startTests() {
    @method setupTestAdapter
  */
 export function setupTestAdapter() {
-  Ember.Test.adapter = QUnitAdapter.create();
+  if (Ember.Test) {
+    Ember.Test.adapter = QUnitAdapter.create();
+  } else {
+    console.warn('Ember.Test was not defined and a test adapter could not be created. This is likely a result of running tests with --environment=production. If this is the case please do not call setupTestAdapter() when running tests in a production enviroment or pass {setupTestAdapter: false} when calling `ember-qunit`\'s start() function.');
+  }
 }
 
 /**


### PR DESCRIPTION
…s not defined

I've been working on upgrading [Ember Data to ember-qunit 4.0](https://github.com/emberjs/data/pull/5371) and one of the things the ember test suite does is run a subset of the tests with the `--environment=production` flag. Currently this does not work with ember-qunit because it expects `Ember.Test` to always be defined but it is not exported by the production builds of Ember.