### PR TITLE
Polyfill memory leak prevention.

### DIFF
--- a/addon-test-support/ember-qunit/index.js
+++ b/addon-test-support/ember-qunit/index.js
@@ -243,6 +243,21 @@ export function setupTestIsolationValidation() {
   QUnit.done(reportIfTestNotIsolated);
 }
 
+// This polyfills the changes from https://github.com/qunitjs/qunit/pull/1279
+// and should be removed when that change is released and included in a release
+// version of QUnit
+function polyfillMemoryLeakPrevention() {
+  QUnit.testDone(function() {
+    // release the test callback
+    QUnit.config.current.callback = undefined;
+  });
+
+  QUnit.moduleDone(function() {
+    // release the module hooks
+    QUnit.config.current.module.hooks = {};
+  });
+}
+
 /**
    @method start
    @param {Object} [options] Options to be used for enabling/disabling behaviors
@@ -260,6 +275,7 @@ export function setupTestIsolationValidation() {
    of `Ember.onerror` will be disabled.
    @param {Boolean} [options.setupTestIsolationValidation] If `false` test isolation validation
    will be disabled.
+   @param {Boolean} [options._polyfillMemoryLeakPrevention] If `false` the polyfilled memory leak prevention will not be enabled.
  */
 export function start(options = {}) {
   if (options.loadTests !== false) {
@@ -287,6 +303,10 @@ export function start(options = {}) {
     options.setupTestIsolationValidation !== false
   ) {
     setupTestIsolationValidation();
+  }
+
+  if (options._polyfillMemoryLeakPrevention !== false) {
+    polyfillMemoryLeakPrevention();
   }
 
   if (options.startTests !== false) {


### PR DESCRIPTION
This polyfills the changes from https://github.com/qunitjs/qunit/pull/1279 to older versions of QUnit.

---

Prior to the changes in this PR, all module and test callbacks are retained (forever). This may not seem significant, but as folks use closure scope to store data across tests (which is very common).

For example, prior to the changes in this PR the following would retain the local variable:

```js
QUnit.module('top', function(hooks) {
  let largeThing;

  hooks.beforeEach(function() {
    largeThing = new LargeThing();
  });

  hooks.afterEach(function() {
    largeThing.destroy();
  });

  test('something that uses largeThing', function(assert) {
    // ...snip...
    largeThing.someMethod();
  });
});
```

In larger test suites, this _really_ adds up...