### PR TITLE
Improve ModuleLoadFailure handling

### DIFF
--- a/addon-test-support/ember-qunit/test-loader.js
+++ b/addon-test-support/ember-qunit/test-loader.js
@@ -15,8 +15,19 @@ addModuleIncludeMatcher(function(moduleName) {
 let moduleLoadFailures = [];
 
 QUnit.done(function() {
-  if (moduleLoadFailures.length) {
-    throw new Error('\n' + moduleLoadFailures.join('\n'));
+  let length = moduleLoadFailures.length;
+  
+  try {
+    if (length === 0) {
+      // do nothing
+    } else if (length === 1) {
+      throw moduleLoadFailures[0];
+    } else {
+      throw new Error('\n' + moduleLoadFailures.join('\n'));
+    }
+  } finally {
+    // ensure we release previously captured errors.
+    moduleLoadFailures = [];
   }
 });
 


### PR DESCRIPTION
1. if only 1 error is found, throw that (rather then joining)
2. after throwing, release errors captured in `moduleLoadFailures`