### PR TITLE
Remove polyfillMemoryLeakPrevention

### DIFF
--- a/addon-test-support/ember-qunit/index.js
+++ b/addon-test-support/ember-qunit/index.js
@@ -243,21 +243,6 @@ export function setupTestIsolationValidation() {
   QUnit.done(reportIfTestNotIsolated);
 }
 
-// This polyfills the changes from https://github.com/qunitjs/qunit/pull/1279
-// and should be removed when that change is released and included in a release
-// version of QUnit
-function polyfillMemoryLeakPrevention() {
-  QUnit.testDone(function() {
-    // release the test callback
-    QUnit.config.current.callback = undefined;
-  });
-
-  QUnit.moduleDone(function() {
-    // release the module hooks
-    QUnit.config.current.module.hooks = {};
-  });
-}
-
 /**
    @method start
    @param {Object} [options] Options to be used for enabling/disabling behaviors
@@ -275,7 +260,6 @@ function polyfillMemoryLeakPrevention() {
    of `Ember.onerror` will be disabled.
    @param {Boolean} [options.setupTestIsolationValidation] If `false` test isolation validation
    will be disabled.
-   @param {Boolean} [options._polyfillMemoryLeakPrevention] If `false` the polyfilled memory leak prevention will not be enabled.
  */
 export function start(options = {}) {
   if (options.loadTests !== false) {
@@ -303,10 +287,6 @@ export function start(options = {}) {
     options.setupTestIsolationValidation !== false
   ) {
     setupTestIsolationValidation();
-  }
-
-  if (options._polyfillMemoryLeakPrevention !== false) {
-    polyfillMemoryLeakPrevention();
   }
 
   if (options.startTests !== false) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "common-tags": "^1.4.0",
     "ember-cli-babel": "^6.8.2",
     "ember-cli-test-loader": "^2.2.0",
-    "qunit": "^2.5.0"
+    "qunit": "^2.6.0"
   },
   "devDependencies": {
     "ember-cli": "~2.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6166,7 +6166,7 @@ quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quick-temp@^0.1.8:
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
 
-qunit@^2.5.0:
+qunit@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.6.2.tgz#551210c5cf857258a4fe39a7fe15d9e14dfef22c"
   integrity sha512-PHbKulmd4rrDhFto7iHicIstDTX7oMRvAcI7loHstvU8J7AOGwzcchONmy+EG4KU8HDk0K90o7vO0GhlYyKlOg==


### PR DESCRIPTION
As of qunit@2.6.0, this polyfill is no longer necessary and can cause issues
in apps the implement ember-qunit