### PR TITLE
Update @ember/test-helpers to v0.7.26.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "@ember/test-helpers": "^0.7.25",
+    "@ember/test-helpers": "^0.7.26",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",
     "common-tags": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,13 @@
 # yarn lockfile v1
 
 
-"@ember/test-helpers@^0.7.25":
-  version "0.7.25"
-  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-0.7.25.tgz#b4014c108b40ffaf74f3c4d5918800917541541d"
-  integrity sha1-tAFMEItA/69088TVkYgAkXVBVB0=
+"@ember/test-helpers@^0.7.26":
+  version "0.7.26"
+  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-0.7.26.tgz#ae11cbde9cce2c872abbea6edcd849a31dd7bd1e"
+  integrity sha512-5HxPYmdeinI4f0lF2tKHyiNGTcNY3O5rw89AC6Z6hb9yEL3ktF8eaU7rZfvSTFEF3d3TlhR5Qidl27QzLGkUeA==
   dependencies:
     broccoli-funnel "^2.0.1"
+    ember-assign-polyfill "~2.4.0"
     ember-cli-babel "^6.12.0"
     ember-cli-htmlbars-inline-precompile "^1.0.0"
 
@@ -2176,6 +2177,14 @@ electron-to-chromium@^1.3.47:
   version "1.3.70"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.70.tgz#ded377256d92d81b4257d36c65aa890274afcfd2"
   integrity sha512-WYMjqCnPVS5JA+XvwEnpwucJpVi2+q9cdCFpbhxgWGsCtforFBEkuP9+nCyy/wnU/0SyLcLRIeZct9ayMGcXoQ==
+
+ember-assign-polyfill@~2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/ember-assign-polyfill/-/ember-assign-polyfill-2.4.0.tgz#acb00466f7d674b3e6b030acfe255b3b1f6472e1"
+  integrity sha512-0SnGQb9CenRqbZdIa1KFsEjT+1ijGWfAbCSaDbg5uVa5l6HPdppuTzOXK6sfEQMsd2nbrp27QWFy7W5VX6l4Ag==
+  dependencies:
+    ember-cli-babel "^6.6.0"
+    ember-cli-version-checker "^2.0.0"
 
 ember-cli-babel@^6.0.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.4.1, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0:
   version "6.17.2"


### PR DESCRIPTION
<details>
<summary>Release notes</summary>

* [#410](https://github.com/emberjs/ember-test-helpers/pull/410) Use `assign` instead of deprecated `merge`. ([@wagenet](https://github.com/wagenet))
* [#397](https://github.com/emberjs/ember-test-helpers/pull/397) Add `typeIn` helper to trigger `keyup`, `keypress` and `keyup` events when filling inputs. ([@mfeckie](https://github.com/mfeckie))
* [#398](https://github.com/emberjs/ember-test-helpers/pull/398) Add options to `click`, `doubleClick`, and `tap`. ([@BryanCrotaz](https://github.com/BryanCrotaz))
* [#387](https://github.com/emberjs/ember-test-helpers/pull/387) Update `buildMouseEvent` to use `MouseEvent` constructor if it is present. ([@ggayowsky](https://github.com/ggayowsky))
* [#391](https://github.com/emberjs/ember-test-helpers/pull/391) Add numbers to `keyFromKeyCode`. ([@localpcguy](https://github.com/localpcguy))
* [#392](https://github.com/emberjs/ember-test-helpers/pull/392) Include selector in `waitFor()`'s default timeout message. ([@gabrielgrant](https://github.com/gabrielgrant))
* [#382](https://github.com/emberjs/ember-test-helpers/pull/382) Add `doubleClick` helper. ([@mmun](https://github.com/mmun))

* [#413](https://github.com/emberjs/ember-test-helpers/pull/413) Clear requests array when tearing down. ([@hjdivad](https://github.com/hjdivad))
* [#404](https://github.com/emberjs/ember-test-helpers/pull/404) Fix `getRootElement` failing when `Application.rootElement` is an element. ([@apellerano-pw](https://github.com/apellerano-pw))

* [#408](https://github.com/emberjs/ember-test-helpers/pull/408) Update `setupApplicationContext` documentation. ([@vitch](https://github.com/vitch))
* [#340](https://github.com/emberjs/ember-test-helpers/pull/340) Add some specific documentation for uploading files. ([@jrjohnson](https://github.com/jrjohnson))
* [#396](https://github.com/emberjs/ember-test-helpers/pull/396) docs(api): try fixing `getSettledState` list. ([@knownasilya](https://github.com/knownasilya))
* [#199](https://github.com/emberjs/ember-test-helpers/pull/199) Replace hard-coded guides link with /current. ([@acorncom](https://github.com/acorncom))
* [#386](https://github.com/emberjs/ember-test-helpers/pull/386) Fix `waitFor` return value documentation. ([@pcambra](https://github.com/pcambra))

* [#412](https://github.com/emberjs/ember-test-helpers/pull/412) Work around downstream dependencies dropping Node 4 without major bump. ([@rwjblue](https://github.com/rwjblue))

- Andrew Pellerano ([apellerano-pw](https://github.com/apellerano-pw))
- Bryan ([BryanCrotaz](https://github.com/BryanCrotaz))
- David Baker ([acorncom](https://github.com/acorncom))
- David J. Hamilton ([hjdivad](https://github.com/hjdivad))
- Gabriel Grant ([gabrielgrant](https://github.com/gabrielgrant))
- Ilya Radchenko ([knownasilya](https://github.com/knownasilya))
- Jonathan Johnson ([jrjohnson](https://github.com/jrjohnson))
- Kelvin Luck ([vitch](https://github.com/vitch))
- Martin Feckie ([mfeckie](https://github.com/mfeckie))
- Martin Muñoz ([mmun](https://github.com/mmun))
- Mike Behnke ([localpcguy](https://github.com/localpcguy))
- Pedro ([pcambra](https://github.com/pcambra))
- Peter Wagenet ([wagenet](https://github.com/wagenet))
- Robert Jackson ([rwjblue](https://github.com/rwjblue))
- [ggayowsky](https://github.com/ggayowsky)
</details>