### PR TITLE
Pin `qunit` dependency to v2.6.x for Node 4 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "common-tags": "^1.4.0",
     "ember-cli-babel": "^6.8.2",
     "ember-cli-test-loader": "^2.2.0",
-    "qunit": "^2.7.0"
+    "qunit": "~2.6.0"
   },
   "devDependencies": {
     "ember-cli": "~2.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6175,17 +6175,17 @@ quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quick-temp@^0.1.8:
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
 
-qunit@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.7.0.tgz#32a605c90e9291713b53609d4cf1bb25d513eee8"
-  integrity sha512-YQa/1ckkBHFIs5e7+iqh93H31F2zzZhRbC4dUeI+CuOvW7otfpu4H66DRkFLyVWLozNl4KKRQ9idjL7CNGafXg==
+qunit@~2.6.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.6.2.tgz#551210c5cf857258a4fe39a7fe15d9e14dfef22c"
+  integrity sha512-PHbKulmd4rrDhFto7iHicIstDTX7oMRvAcI7loHstvU8J7AOGwzcchONmy+EG4KU8HDk0K90o7vO0GhlYyKlOg==
   dependencies:
     commander "2.12.2"
     exists-stat "1.0.0"
     findup-sync "2.0.0"
     js-reporters "1.2.1"
     resolve "1.5.0"
-    sane "^4.0.0"
+    sane "^2.5.2"
     walk-sync "0.3.2"
 
 randomatic@^3.0.0:


### PR DESCRIPTION
related to https://github.com/qunitjs/qunit/issues/1321

We can unpin it later, but should officially drop Node 4 support before that and bump major versions here.

/cc @stefanpenner @rwjblue 