### PR TITLE
Drop support for Node.js 4 and below

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "4"
+  - "6"
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prettier": "1.12.1"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "6.* || 8.* || >= 10.*"
   },
   "changelog": {
     "repo": "emberjs/ember-qunit",


### PR DESCRIPTION
Unblocks several dependency updates including `qunit` itself. This is a breaking change and requires a major version bump! (or a minor bump in this case as we're still pre-1.0)