### PR TITLE
Adding debug info to test isolation validation

### DIFF
--- a/addon-test-support/ember-qunit/-internal/get-debug-info-available.js
+++ b/addon-test-support/ember-qunit/-internal/get-debug-info-available.js
@@ -1,0 +1,5 @@
+import { run } from '@ember/runloop';
+
+export default function getDebugInfoAvailable() {
+  return typeof run.backburner.getDebugInfo === 'function';
+}

--- a/addon-test-support/ember-qunit/-internal/test-debug-info-summary.js
+++ b/addon-test-support/ember-qunit/-internal/test-debug-info-summary.js
@@ -1,0 +1,149 @@
+const PENDING_REQUESTS = 'Pending AJAX requests';
+const PENDING_TEST_WAITERS = 'Pending test waiters: YES';
+const PENDING_TIMERS = 'Pending timers';
+const PENDING_SCHEDULED_ITEMS = 'Pending scheduled items';
+const ACTIVE_RUNLOOPS = 'Active runloops: YES';
+
+export function getSummary(testCounts, leakCounts, testNames) {
+  let leakInfo =
+    leakCounts.length > 0
+      ? `We found the following information that may help you identify code that violated test isolation: \n
+  ${leakCounts.join('\n')}
+   \n`
+      : '';
+  let summary = `TESTS ARE NOT ISOLATED\n
+ The following ${testCounts} test(s) have one or more issues that are resulting in non-isolation (async execution is extending beyond the duration of the test):\n
+ ${testNames.join('\n')}
+\n
+ ${leakInfo}
+ More information has been printed to the console. Please use that information to help in debugging.
+`;
+
+  return summary;
+}
+
+export default class TestDebugInfoSummary {
+  constructor() {
+    this.reset();
+  }
+
+  add(testDebugInfo) {
+    let summary = testDebugInfo.summary;
+
+    this._testDebugInfos.push(testDebugInfo);
+
+    this.fullTestNames.push(summary.fullTestName);
+    if (summary.hasPendingRequests) {
+      this.hasPendingRequests = true;
+    }
+    if (summary.hasPendingWaiters) {
+      this.hasPendingWaiters = true;
+    }
+    if (summary.hasRunLoop) {
+      this.hasRunLoop = true;
+    }
+    if (summary.hasPendingTimers) {
+      this.hasPendingTimers = true;
+    }
+    if (summary.pendingScheduledQueueItemCount > 0) {
+      this.hasPendingScheduledQueueItems = true;
+    }
+
+    this.totalPendingRequestCount += summary.pendingRequestCount;
+    this.totalPendingTimersCount += summary.pendingTimersCount;
+    this.totalPendingScheduledQueueItemCount += summary.pendingScheduledQueueItemCount;
+  }
+
+  get hasDebugInfo() {
+    return this._testDebugInfos.length > 0;
+  }
+
+  reset() {
+    this._testDebugInfos = [];
+    this.fullTestNames = [];
+    this.hasPendingRequests = false;
+    this.hasPendingWaiters = false;
+    this.hasRunLoop = false;
+    this.hasPendingTimers = false;
+    this.hasPendingScheduledQueueItems = false;
+    this.totalPendingRequestCount = 0;
+    this.totalPendingTimersCount = 0;
+    this.totalPendingScheduledQueueItemCount = 0;
+  }
+
+  printToConsole(_console = console) {
+    _console.group('Tests not isolated');
+
+    this._testDebugInfos.forEach(testDebugInfo => {
+      let summary = testDebugInfo.summary;
+
+      _console.group(summary.fullTestName);
+
+      if (summary.hasPendingRequests) {
+        _console.log(this.formatCount(PENDING_REQUESTS, summary.pendingRequestCount));
+      }
+
+      if (summary.hasPendingWaiters) {
+        _console.log(PENDING_TEST_WAITERS);
+      }
+
+      if (summary.hasPendingTimers) {
+        _console.group(this.formatCount(PENDING_TIMERS, summary.pendingTimersCount));
+        summary.pendingTimersStackTraces.forEach(stackTrace => {
+          _console.log(stackTrace);
+        });
+        _console.groupEnd();
+      }
+
+      if (summary.hasPendingScheduledQueueItems) {
+        _console.group(
+          this.formatCount(PENDING_SCHEDULED_ITEMS, summary.pendingScheduledQueueItemCount)
+        );
+        summary.pendingScheduledQueueItemStackTraces.forEach(stackTrace => {
+          _console.log(stackTrace);
+        });
+        _console.groupEnd();
+      }
+
+      if (summary.hasRunLoop) {
+        _console.log(ACTIVE_RUNLOOPS);
+      }
+
+      _console.groupEnd();
+    });
+
+    _console.groupEnd();
+  }
+
+  formatForBrowser() {
+    let leakCounts = [];
+
+    if (this.hasPendingRequests) {
+      leakCounts.push(this.formatCount(PENDING_REQUESTS, this.totalPendingRequestCount));
+    }
+
+    if (this.hasPendingWaiters) {
+      leakCounts.push(PENDING_TEST_WAITERS);
+    }
+
+    if (this.hasPendingTimers) {
+      leakCounts.push(this.formatCount(PENDING_TIMERS, this.totalPendingTimersCount));
+    }
+
+    if (this.hasPendingScheduledQueueItems) {
+      leakCounts.push(
+        this.formatCount(PENDING_SCHEDULED_ITEMS, this.totalPendingScheduledQueueItemCount)
+      );
+    }
+
+    if (this.hasRunLoop) {
+      leakCounts.push(ACTIVE_RUNLOOPS);
+    }
+
+    return getSummary(this._testDebugInfos.length, leakCounts, this.fullTestNames);
+  }
+
+  formatCount(title, count) {
+    return `${title}: ${count}`;
+  }
+}

--- a/addon-test-support/ember-qunit/-internal/test-debug-info-summary.js
+++ b/addon-test-support/ember-qunit/-internal/test-debug-info-summary.js
@@ -24,7 +24,16 @@ export function getSummary(testCounts, leakCounts, testNames) {
 
 export default class TestDebugInfoSummary {
   constructor() {
-    this.reset();
+    this._testDebugInfos = [];
+    this.fullTestNames = [];
+    this.hasPendingRequests = false;
+    this.hasPendingWaiters = false;
+    this.hasRunLoop = false;
+    this.hasPendingTimers = false;
+    this.hasPendingScheduledQueueItems = false;
+    this.totalPendingRequestCount = 0;
+    this.totalPendingTimersCount = 0;
+    this.totalPendingScheduledQueueItemCount = 0;
   }
 
   add(testDebugInfo) {
@@ -56,19 +65,6 @@ export default class TestDebugInfoSummary {
 
   get hasDebugInfo() {
     return this._testDebugInfos.length > 0;
-  }
-
-  reset() {
-    this._testDebugInfos = [];
-    this.fullTestNames = [];
-    this.hasPendingRequests = false;
-    this.hasPendingWaiters = false;
-    this.hasRunLoop = false;
-    this.hasPendingTimers = false;
-    this.hasPendingScheduledQueueItems = false;
-    this.totalPendingRequestCount = 0;
-    this.totalPendingTimersCount = 0;
-    this.totalPendingScheduledQueueItemCount = 0;
   }
 
   printToConsole(_console = console) {

--- a/addon-test-support/ember-qunit/-internal/test-debug-info.js
+++ b/addon-test-support/ember-qunit/-internal/test-debug-info.js
@@ -1,0 +1,63 @@
+/**
+ * Encapsulates debug information for an individual test. Aggregates information
+ * from:
+ * - the test info provided by qunit (module & name)
+ * - info provided by @ember/test-helper's getSettledState function
+ *    - hasPendingTimers
+ *    - hasRunLoop
+ *    - hasPendingWaiters
+ *    - hasPendingRequests
+ *    - pendingRequestCount
+ * - info provided by backburner's getDebugInfo method (timers, schedules, and stack trace info)
+ */
+export default class TestDebugInfo {
+  constructor(module, name, settledState, debugInfo) {
+    this.module = module;
+    this.name = name;
+    this.settledState = settledState;
+    this.debugInfo = debugInfo;
+  }
+
+  get fullTestName() {
+    return `${this.module}: ${this.name}`;
+  }
+
+  get summary() {
+    if (!this._summaryInfo) {
+      this._summaryInfo = Object.assign(
+        {
+          fullTestName: this.fullTestName,
+        },
+        this.settledState
+      );
+
+      if (this.debugInfo) {
+        this._summaryInfo.pendingTimersCount = this.debugInfo.timers.length;
+        this._summaryInfo.pendingTimersStackTraces = this.debugInfo.timers.map(
+          timer => timer.stack
+        );
+        this._summaryInfo.pendingScheduledQueueItemCount = this.debugInfo.instanceStack
+          .filter(q => q)
+          .reduce((total, item) => {
+            Object.keys(item).forEach(queueName => {
+              total += item[queueName].length;
+            });
+
+            return total;
+          }, 0);
+        this._summaryInfo.pendingScheduledQueueItemStackTraces = this.debugInfo.instanceStack
+          .filter(q => q)
+          .reduce((stacks, deferredActionQueues) => {
+            Object.keys(deferredActionQueues).forEach(queue => {
+              deferredActionQueues[queue].forEach(
+                queueItem => queueItem.stack && stacks.push(queueItem.stack)
+              );
+            });
+            return stacks;
+          }, []);
+      }
+    }
+
+    return this._summaryInfo;
+  }
+}

--- a/addon-test-support/ember-qunit/test-isolation-validation.js
+++ b/addon-test-support/ember-qunit/test-isolation-validation.js
@@ -4,8 +4,8 @@ import TestDebugInfo from './-internal/test-debug-info';
 import TestDebugInfoSummary from './-internal/test-debug-info-summary';
 import getDebugInfoAvailable from './-internal/get-debug-info-available';
 
-const nonIsolatedTests = new TestDebugInfoSummary();
 const { backburner } = run;
+let nonIsolatedTests;
 
 /**
  * Detects if a specific test isn't isolated. A test is considered
@@ -22,6 +22,8 @@ const { backburner } = run;
  * @param {string} testInfo.name The test name
  */
 export function detectIfTestNotIsolated({ module, name }) {
+  nonIsolatedTests = new TestDebugInfoSummary();
+
   if (!isSettled()) {
     let testDebugInfo;
     let backburnerDebugInfo;
@@ -47,7 +49,6 @@ export function detectIfTestNotIsolated({ module, name }) {
 export function reportIfTestNotIsolated() {
   if (nonIsolatedTests.hasDebugInfo) {
     nonIsolatedTests.printToConsole();
-    nonIsolatedTests.reset();
 
     throw new Error(nonIsolatedTests.formatForBrowser());
   }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^5.0.1",
-    "ember-source": "~3.5.0",
+    "ember-source": "3.4.5",
     "ember-source-channel-url": "^1.0.1",
     "ember-try": "^1.1.0",
     "eslint": "^5.7.0",

--- a/tests/unit/test-debug-info-summary-test.js
+++ b/tests/unit/test-debug-info-summary-test.js
@@ -1,0 +1,122 @@
+import { module, test } from 'qunit';
+import TestDebugInfoSummary, { getSummary } from 'ember-qunit/-internal/test-debug-info-summary';
+import TestDebugInfo from 'ember-qunit/-internal/test-debug-info';
+import { MockConsole, getSettledState, debugInfo } from './utils/test-isolation-helpers';
+
+module('TestDebugInfoSummary', function() {
+  test('hasDebugInfo returns true if TestDebugInfos have been added', function(assert) {
+    assert.expect(1);
+
+    let testDebugInfoSummary = new TestDebugInfoSummary();
+
+    testDebugInfoSummary.add(new TestDebugInfo('foo', 'bar', {}));
+    testDebugInfoSummary.add(new TestDebugInfo('ding', 'bat', {}));
+
+    assert.ok(testDebugInfoSummary.hasDebugInfo);
+  });
+
+  test('reset correctly resets to default values', function(assert) {
+    assert.expect(2);
+
+    let testDebugInfoSummary = new TestDebugInfoSummary();
+
+    testDebugInfoSummary.add(new TestDebugInfo('foo', 'bar', {}));
+    testDebugInfoSummary.add(new TestDebugInfo('ding', 'bat', {}));
+
+    assert.ok(testDebugInfoSummary.hasDebugInfo);
+
+    testDebugInfoSummary.reset();
+
+    assert.notOk(testDebugInfoSummary.hasDebugInfo);
+  });
+
+  test('printToConsole correctly prints minimal information', function(assert) {
+    assert.expect(1);
+
+    let mockConsole = new MockConsole();
+    let testDebugInfoSummary = new TestDebugInfoSummary();
+
+    testDebugInfoSummary.add(new TestDebugInfo('foo', 'bar', getSettledState()));
+    testDebugInfoSummary.add(new TestDebugInfo('ding', 'bat', getSettledState()));
+
+    testDebugInfoSummary.printToConsole(mockConsole);
+
+    assert.deepEqual(
+      mockConsole.toString(),
+      `Tests not isolated
+foo: bar
+ding: bat`
+    );
+  });
+
+  test('printToConsole correctly prints all information', function(assert) {
+    assert.expect(1);
+
+    let mockConsole = new MockConsole();
+    let testDebugInfoSummary = new TestDebugInfoSummary();
+
+    testDebugInfoSummary.add(
+      new TestDebugInfo('foo', 'bar', getSettledState(true, true), debugInfo)
+    );
+    testDebugInfoSummary.add(
+      new TestDebugInfo('ding', 'bat', getSettledState(false, true, false, true, 2), debugInfo)
+    );
+
+    testDebugInfoSummary.printToConsole(mockConsole);
+
+    assert.deepEqual(
+      mockConsole.toString(),
+      `Tests not isolated
+foo: bar
+Pending timers: 2
+STACK
+STACK
+Active runloops: YES
+ding: bat
+Pending AJAX requests: 2
+Active runloops: YES`
+    );
+  });
+
+  test('formatForBrowser correctly prints minimal information', function(assert) {
+    assert.expect(1);
+
+    let testDebugInfoSummary = new TestDebugInfoSummary();
+
+    testDebugInfoSummary.add(new TestDebugInfo('foo', 'bar', getSettledState()));
+    testDebugInfoSummary.add(new TestDebugInfo('ding', 'bat', getSettledState()));
+
+    let browserOutput = testDebugInfoSummary.formatForBrowser();
+
+    assert.equal(browserOutput, getSummary(2, 0, ['foo: bar', 'ding: bat']));
+  });
+
+  test('formatForBrowser correctly prints all information', function(assert) {
+    assert.expect(1);
+
+    let testDebugInfoSummary = new TestDebugInfoSummary();
+
+    testDebugInfoSummary.add(
+      new TestDebugInfo('foo', 'bar', getSettledState(true, true), debugInfo)
+    );
+    testDebugInfoSummary.add(
+      new TestDebugInfo('ding', 'bat', getSettledState(false, true, false, true, 2), debugInfo)
+    );
+
+    let browserOutput = testDebugInfoSummary.formatForBrowser();
+
+    assert.equal(
+      browserOutput,
+      getSummary(
+        2,
+        [
+          'Pending AJAX requests: 2',
+          'Pending timers: 4',
+          'Pending scheduled items: 4',
+          'Active runloops: YES',
+        ],
+        ['foo: bar', 'ding: bat']
+      )
+    );
+  });
+});

--- a/tests/unit/test-debug-info-summary-test.js
+++ b/tests/unit/test-debug-info-summary-test.js
@@ -15,21 +15,6 @@ module('TestDebugInfoSummary', function() {
     assert.ok(testDebugInfoSummary.hasDebugInfo);
   });
 
-  test('reset correctly resets to default values', function(assert) {
-    assert.expect(2);
-
-    let testDebugInfoSummary = new TestDebugInfoSummary();
-
-    testDebugInfoSummary.add(new TestDebugInfo('foo', 'bar', {}));
-    testDebugInfoSummary.add(new TestDebugInfo('ding', 'bat', {}));
-
-    assert.ok(testDebugInfoSummary.hasDebugInfo);
-
-    testDebugInfoSummary.reset();
-
-    assert.notOk(testDebugInfoSummary.hasDebugInfo);
-  });
-
   test('printToConsole correctly prints minimal information', function(assert) {
     assert.expect(1);
 

--- a/tests/unit/test-debug-info-test.js
+++ b/tests/unit/test-debug-info-test.js
@@ -1,0 +1,133 @@
+import { module, test } from 'qunit';
+import { run } from '@ember/runloop';
+import TestDebugInfo from 'ember-qunit/-internal/test-debug-info';
+import getDebugInfoAvailable from 'ember-qunit/-internal/get-debug-info-available';
+import MockStableError, { overrideError, resetError } from './utils/mock-stable-error';
+import { randomBoolean, getSettledState, debugInfo } from './utils/test-isolation-helpers';
+
+module('TestDebugInfo', function() {
+  test('fullTestName returns concatenated test name', function(assert) {
+    assert.expect(1);
+
+    let testDebugInfo = new TestDebugInfo('foo', 'bar', {});
+
+    assert.equal(testDebugInfo.fullTestName, 'foo: bar');
+  });
+
+  test('summary returns minimal information when debugInfo is not present', function(assert) {
+    assert.expect(1);
+
+    let hasPendingTimers = randomBoolean();
+    let hasPendingWaiters = randomBoolean();
+    let hasRunLoop = randomBoolean();
+    let pendingRequestCount = Math.floor(Math.random(10));
+    let hasPendingRequests = Boolean(pendingRequestCount > 0);
+    let testDebugInfo = new TestDebugInfo(
+      'foo',
+      'bar',
+      getSettledState(
+        hasPendingTimers,
+        hasRunLoop,
+        hasPendingWaiters,
+        hasPendingRequests,
+        pendingRequestCount
+      )
+    );
+
+    assert.deepEqual(testDebugInfo.summary, {
+      fullTestName: 'foo: bar',
+      hasPendingRequests,
+      hasPendingTimers,
+      hasPendingWaiters,
+      hasRunLoop,
+      pendingRequestCount,
+    });
+  });
+
+  test('summary returns full information when debugInfo is present', function(assert) {
+    assert.expect(1);
+
+    let testDebugInfo = new TestDebugInfo('foo', 'bar', getSettledState(), debugInfo);
+
+    assert.deepEqual(testDebugInfo.summary, {
+      fullTestName: 'foo: bar',
+      hasPendingRequests: false,
+      hasPendingTimers: false,
+      hasPendingWaiters: false,
+      hasRunLoop: false,
+      pendingRequestCount: 0,
+      pendingScheduledQueueItemCount: 2,
+      pendingScheduledQueueItemStackTraces: ['STACK', 'STACK'],
+      pendingTimersCount: 2,
+      pendingTimersStackTraces: ['STACK', 'STACK'],
+    });
+  });
+
+  if (getDebugInfoAvailable()) {
+    module('when using backburner', function(hooks) {
+      let cancelIds;
+
+      hooks.beforeEach(function() {
+        cancelIds = [];
+        overrideError(MockStableError);
+      });
+
+      hooks.afterEach(function() {
+        cancelIds.forEach(cancelId => run.cancel(cancelId));
+
+        run.backburner.DEBUG = false;
+
+        resetError();
+      });
+
+      test('summary returns full information when debugInfo is present', function(assert) {
+        assert.expect(1);
+
+        run.backburner.DEBUG = true;
+
+        cancelIds.push(run.later(() => {}, 5000));
+
+        let debugInfo = run.backburner.getDebugInfo();
+        let testDebugInfo = new TestDebugInfo('foo', 'bar', getSettledState(), debugInfo);
+
+        assert.deepEqual(testDebugInfo.summary, {
+          fullTestName: 'foo: bar',
+          hasPendingRequests: false,
+          hasPendingTimers: false,
+          hasPendingWaiters: false,
+          hasRunLoop: false,
+          pendingRequestCount: 0,
+          pendingScheduledQueueItemCount: 0,
+          pendingScheduledQueueItemStackTraces: [],
+          pendingTimersCount: 1,
+          pendingTimersStackTraces: ['STACK'],
+        });
+      });
+
+      test('summary returns full information when debugInfo is present', function(assert) {
+        assert.expect(1);
+
+        run.backburner.DEBUG = true;
+
+        cancelIds.push(run.later(() => {}, 5000));
+        cancelIds.push(run.later(() => {}, 10000));
+
+        let debugInfo = run.backburner.getDebugInfo();
+        let testDebugInfo = new TestDebugInfo('foo', 'bar', getSettledState(), debugInfo);
+
+        assert.deepEqual(testDebugInfo.summary, {
+          fullTestName: 'foo: bar',
+          hasPendingRequests: false,
+          hasPendingTimers: false,
+          hasPendingWaiters: false,
+          hasRunLoop: false,
+          pendingRequestCount: 0,
+          pendingScheduledQueueItemCount: 0,
+          pendingScheduledQueueItemStackTraces: [],
+          pendingTimersCount: 2,
+          pendingTimersStackTraces: ['STACK', 'STACK'],
+        });
+      });
+    });
+  }
+});

--- a/tests/unit/test-isolation-validation-test.js
+++ b/tests/unit/test-isolation-validation-test.js
@@ -4,10 +4,9 @@ import { module, test } from 'qunit';
 import {
   detectIfTestNotIsolated,
   reportIfTestNotIsolated,
-  getMessage,
 } from 'ember-qunit/test-isolation-validation';
 
-module('setupTestIsolationValidation', function(hooks) {
+module('test isolation validation', function(hooks) {
   hooks.beforeEach(function() {
     this.cancelId = 0;
 
@@ -47,13 +46,9 @@ module('setupTestIsolationValidation', function(hooks) {
 
     detectIfTestNotIsolated({ module: 'foo', name: 'bar' });
 
-    assert.throws(
-      function() {
-        reportIfTestNotIsolated();
-      },
-      Error,
-      getMessage(1, 'foo: bar')
-    );
+    assert.throws(function() {
+      reportIfTestNotIsolated();
+    });
   });
 
   test('reportIfTestNotIsolated throws when test has test waiters', function(assert) {
@@ -63,12 +58,8 @@ module('setupTestIsolationValidation', function(hooks) {
 
     detectIfTestNotIsolated({ module: 'foo', name: 'bar' });
 
-    assert.throws(
-      function() {
-        reportIfTestNotIsolated();
-      },
-      Error,
-      getMessage(1, 'foo: bar')
-    );
+    assert.throws(function() {
+      reportIfTestNotIsolated();
+    });
   });
 });

--- a/tests/unit/utils/mock-stable-error.js
+++ b/tests/unit/utils/mock-stable-error.js
@@ -1,0 +1,19 @@
+/* eslint-disable no-global-assign */
+/* eslint-disable no-unused-vars */
+
+const ERROR = Error;
+
+Error = ERROR;
+
+export function overrideError(_Error) {
+  Error = _Error;
+}
+export function resetError() {
+  Error = ERROR;
+}
+export default class MockStableError {
+  constructor(message) {}
+  get stack() {
+    return 'STACK';
+  }
+}

--- a/tests/unit/utils/test-isolation-helpers.js
+++ b/tests/unit/utils/test-isolation-helpers.js
@@ -1,0 +1,65 @@
+const STACK = 'STACK';
+export const debugInfo = {
+  timers: [
+    {
+      stack: STACK,
+    },
+    {
+      stack: STACK,
+    },
+  ],
+  instanceStack: [
+    {
+      one: [
+        {
+          stack: STACK,
+        },
+      ],
+      two: [
+        {
+          stack: STACK,
+        },
+      ],
+    },
+  ],
+};
+
+export class MockConsole {
+  constructor() {
+    this._buffer = [];
+  }
+
+  group(str) {
+    this._buffer.push(str);
+  }
+
+  log(str) {
+    this._buffer.push(str);
+  }
+
+  groupEnd() {}
+
+  toString() {
+    return this._buffer.join('\n');
+  }
+}
+
+export function randomBoolean() {
+  return Math.random() >= 0.5;
+}
+
+export function getSettledState(
+  hasPendingTimers = false,
+  hasRunLoop = false,
+  hasPendingWaiters = false,
+  hasPendingRequests = false,
+  pendingRequestCount = 0
+) {
+  return {
+    hasPendingTimers,
+    hasRunLoop,
+    hasPendingWaiters,
+    hasPendingRequests,
+    pendingRequestCount,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3234,10 +3234,10 @@ ember-source-channel-url@^1.0.1:
   dependencies:
     got "^8.0.1"
 
-ember-source@~3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.5.0.tgz#2322e393125684e1e043d0eedad8fd79c6de78a8"
-  integrity sha512-q7GAQZI1NAxMdgqxJGKsOgmwFAmvSet33Ub5C/Cn5bkQYWlAgjR7oKiP0DlHTFSbiwmGnZZF9a/sHB7W/XIjPg==
+ember-source@3.4.5:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.4.5.tgz#f4a5975affd393c29a69afaa58c2ca9de8bba6c0"
+  integrity sha512-fm2JyUzIBhYZhMgLerjYMb0sAuv5kTPradWnsdIZbitk+O00ViF7zKb2nTEAb1MtxsUpqRCaxQZsv06LljDvtg==
   dependencies:
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^2.0.0"


### PR DESCRIPTION
This PR builds on the existing work to detect when tests are not isolated. 

Debug info is extracted from backburner using the new `getDebugInfo` method, which allows us to provide information, including stack trace information, to end users. We output that debug info to the console to allow 'click to open' functionality from within the stack traces, and additionally provide a summary of the debug info to test output. 

TODO:
- [x] Add tests to ensure that, when `backburner.DEBUG = true` we gather and output debug info
- [ ] Figure out correct version of ember-source