### PR TITLE
Check QUnit.config.current.assert in asyncStart()

### DIFF
--- a/addon-test-support/ember-qunit/adapter.js
+++ b/addon-test-support/ember-qunit/adapter.js
@@ -28,10 +28,15 @@ function unhandledRejectionAssertion(current, error) {
 let Adapter = Ember.Test.Adapter.extend({
   init() {
     this.doneCallbacks = [];
+    this.qunit = this.qunit || QUnit;
   },
 
   asyncStart() {
-    this.doneCallbacks.push(QUnit.config.current ? QUnit.config.current.assert.async() : null);
+    this.doneCallbacks.push(
+      this.qunit.config.current && this.qunit.config.current.assert
+        ? this.qunit.config.current.assert.async()
+        : null
+    );
   },
 
   asyncEnd() {

--- a/tests/unit/adapter-test.js
+++ b/tests/unit/adapter-test.js
@@ -27,3 +27,17 @@ test('asyncStart waits for equal numbers of asyncEnd to finish a test', function
     adapter.asyncEnd();
   }, 50);
 });
+
+test('asyncStart should handle skipped tests that has no assert', function(assert) {
+  let FakeQUnitWithoutAssert = {
+    config: {
+      current: {},
+    },
+  };
+
+  const adapter = QUnitAdapter.create({ qunit: FakeQUnitWithoutAssert });
+
+  adapter.asyncStart();
+  assert.equal(adapter.doneCallbacks.length, 1);
+  assert.deepEqual(adapter.doneCallbacks, [null]);
+});


### PR DESCRIPTION
Check QUnit.config.current.assert in asyncStart()

**Problem:**
A recent change to QUnit: https://github.com/qunitjs/qunit/pull/1307
Has caused QUnit skipped tests to go through the Ember.RSVP code.

**Solution:**
in asyncStart(), do not add `QUnit.config.current.assert.async()` to `doneCallback` when `QUnit.config.current.assert` is undefined.