### PR TITLE
Bugfix: fixes issue with test-isolation-validation output

### DIFF
--- a/addon-test-support/ember-qunit/-internal/format-count.js
+++ b/addon-test-support/ember-qunit/-internal/format-count.js
@@ -1,0 +1,3 @@
+export default function formatCount(title, count) {
+  return `${title}: ${count}`;
+}

--- a/addon-test-support/ember-qunit/-internal/test-debug-info-summary.js
+++ b/addon-test-support/ember-qunit/-internal/test-debug-info-summary.js
@@ -1,26 +1,10 @@
+import formatCount from './format-count';
+
 const PENDING_REQUESTS = 'Pending AJAX requests';
 const PENDING_TEST_WAITERS = 'Pending test waiters: YES';
 const PENDING_TIMERS = 'Pending timers';
 const PENDING_SCHEDULED_ITEMS = 'Pending scheduled items';
 const ACTIVE_RUNLOOPS = 'Active runloops: YES';
-
-export function getSummary(testCounts, leakCounts, testNames) {
-  let leakInfo =
-    leakCounts.length > 0
-      ? `We found the following information that may help you identify code that violated test isolation: \n
-  ${leakCounts.join('\n')}
-   \n`
-      : '';
-  let summary = `TESTS ARE NOT ISOLATED\n
- The following ${testCounts} test(s) have one or more issues that are resulting in non-isolation (async execution is extending beyond the duration of the test):\n
- ${testNames.join('\n')}
-\n
- ${leakInfo}
- More information has been printed to the console. Please use that information to help in debugging.
-`;
-
-  return summary;
-}
 
 export default class TestDebugInfoSummary {
   constructor() {
@@ -67,6 +51,10 @@ export default class TestDebugInfoSummary {
     return this._testDebugInfos.length > 0;
   }
 
+  forEach(fn) {
+    this._testDebugInfos.forEach(fn);
+  }
+
   printToConsole(_console = console) {
     _console.group('Tests not isolated');
 
@@ -76,7 +64,7 @@ export default class TestDebugInfoSummary {
       _console.group(summary.fullTestName);
 
       if (summary.hasPendingRequests) {
-        _console.log(this.formatCount(PENDING_REQUESTS, summary.pendingRequestCount));
+        _console.log(formatCount(PENDING_REQUESTS, summary.pendingRequestCount));
       }
 
       if (summary.hasPendingWaiters) {
@@ -84,7 +72,7 @@ export default class TestDebugInfoSummary {
       }
 
       if (summary.hasPendingTimers) {
-        _console.group(this.formatCount(PENDING_TIMERS, summary.pendingTimersCount));
+        _console.group(formatCount(PENDING_TIMERS, summary.pendingTimersCount));
         summary.pendingTimersStackTraces.forEach(stackTrace => {
           _console.log(stackTrace);
         });
@@ -93,7 +81,7 @@ export default class TestDebugInfoSummary {
 
       if (summary.hasPendingScheduledQueueItems) {
         _console.group(
-          this.formatCount(PENDING_SCHEDULED_ITEMS, summary.pendingScheduledQueueItemCount)
+          formatCount(PENDING_SCHEDULED_ITEMS, summary.pendingScheduledQueueItemCount)
         );
         summary.pendingScheduledQueueItemStackTraces.forEach(stackTrace => {
           _console.log(stackTrace);
@@ -109,37 +97,5 @@ export default class TestDebugInfoSummary {
     });
 
     _console.groupEnd();
-  }
-
-  formatForBrowser() {
-    let leakCounts = [];
-
-    if (this.hasPendingRequests) {
-      leakCounts.push(this.formatCount(PENDING_REQUESTS, this.totalPendingRequestCount));
-    }
-
-    if (this.hasPendingWaiters) {
-      leakCounts.push(PENDING_TEST_WAITERS);
-    }
-
-    if (this.hasPendingTimers) {
-      leakCounts.push(this.formatCount(PENDING_TIMERS, this.totalPendingTimersCount));
-    }
-
-    if (this.hasPendingScheduledQueueItems) {
-      leakCounts.push(
-        this.formatCount(PENDING_SCHEDULED_ITEMS, this.totalPendingScheduledQueueItemCount)
-      );
-    }
-
-    if (this.hasRunLoop) {
-      leakCounts.push(ACTIVE_RUNLOOPS);
-    }
-
-    return getSummary(this._testDebugInfos.length, leakCounts, this.fullTestNames);
-  }
-
-  formatCount(title, count) {
-    return `${title}: ${count}`;
   }
 }

--- a/addon-test-support/ember-qunit/-internal/test-debug-info.js
+++ b/addon-test-support/ember-qunit/-internal/test-debug-info.js
@@ -1,3 +1,26 @@
+import formatCount from './format-count';
+
+const PENDING_REQUESTS = 'Pending AJAX requests';
+const PENDING_TEST_WAITERS = 'Pending test waiters: YES';
+const PENDING_TIMERS = 'Pending timers';
+const PENDING_SCHEDULED_ITEMS = 'Pending scheduled items';
+const ACTIVE_RUNLOOPS = 'Active runloops: YES';
+
+export function getSummary(testName, leakCounts) {
+  let leakInfo =
+    leakCounts.length > 0
+      ? `We found the following information that may help you identify code that violated test isolation:
+ ${leakCounts.map(count => `- ${count}`).join('\n')}\n`
+      : '\n';
+  let summary = `'${testName}' is not isolated.\n
+ This test has one or more issues that are resulting in non-isolation (async execution is extending beyond the duration of the test).\n
+ ${leakInfo}
+ More information has been printed to the console. Please use that information to help in debugging.\n
+`;
+
+  return summary;
+}
+
 /**
  * Encapsulates debug information for an individual test. Aggregates information
  * from:
@@ -24,12 +47,7 @@ export default class TestDebugInfo {
 
   get summary() {
     if (!this._summaryInfo) {
-      this._summaryInfo = Object.assign(
-        {
-          fullTestName: this.fullTestName,
-        },
-        this.settledState
-      );
+      this._summaryInfo = Object.assign({ fullTestName: this.fullTestName }, this.settledState);
 
       if (this.debugInfo) {
         this._summaryInfo.pendingTimersCount = this.debugInfo.timers.length;
@@ -59,5 +77,33 @@ export default class TestDebugInfo {
     }
 
     return this._summaryInfo;
+  }
+
+  toString() {
+    let leakCounts = [];
+
+    if (this.summary.hasPendingRequests) {
+      leakCounts.push(formatCount(PENDING_REQUESTS, this.summary.pendingRequestCount));
+    }
+
+    if (this.summary.hasPendingWaiters) {
+      leakCounts.push(PENDING_TEST_WAITERS);
+    }
+
+    if (this.summary.hasPendingTimers) {
+      leakCounts.push(formatCount(PENDING_TIMERS, this.summary.pendingTimersCount));
+    }
+
+    if (this.summary.hasPendingScheduledQueueItems) {
+      leakCounts.push(
+        formatCount(PENDING_SCHEDULED_ITEMS, this.summary.pendingScheduledQueueItemCount)
+      );
+    }
+
+    if (this.summary.hasRunLoop) {
+      leakCounts.push(ACTIVE_RUNLOOPS);
+    }
+
+    return getSummary(this.fullTestName, leakCounts);
   }
 }

--- a/tests/unit/test-debug-info-summary-test.js
+++ b/tests/unit/test-debug-info-summary-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import TestDebugInfoSummary, { getSummary } from 'ember-qunit/-internal/test-debug-info-summary';
+import TestDebugInfoSummary from 'ember-qunit/-internal/test-debug-info-summary';
 import TestDebugInfo from 'ember-qunit/-internal/test-debug-info';
 import { MockConsole, getSettledState, debugInfo } from './utils/test-isolation-helpers';
 
@@ -60,48 +60,6 @@ Active runloops: YES
 ding: bat
 Pending AJAX requests: 2
 Active runloops: YES`
-    );
-  });
-
-  test('formatForBrowser correctly prints minimal information', function(assert) {
-    assert.expect(1);
-
-    let testDebugInfoSummary = new TestDebugInfoSummary();
-
-    testDebugInfoSummary.add(new TestDebugInfo('foo', 'bar', getSettledState()));
-    testDebugInfoSummary.add(new TestDebugInfo('ding', 'bat', getSettledState()));
-
-    let browserOutput = testDebugInfoSummary.formatForBrowser();
-
-    assert.equal(browserOutput, getSummary(2, 0, ['foo: bar', 'ding: bat']));
-  });
-
-  test('formatForBrowser correctly prints all information', function(assert) {
-    assert.expect(1);
-
-    let testDebugInfoSummary = new TestDebugInfoSummary();
-
-    testDebugInfoSummary.add(
-      new TestDebugInfo('foo', 'bar', getSettledState(true, true), debugInfo)
-    );
-    testDebugInfoSummary.add(
-      new TestDebugInfo('ding', 'bat', getSettledState(false, true, false, true, 2), debugInfo)
-    );
-
-    let browserOutput = testDebugInfoSummary.formatForBrowser();
-
-    assert.equal(
-      browserOutput,
-      getSummary(
-        2,
-        [
-          'Pending AJAX requests: 2',
-          'Pending timers: 4',
-          'Pending scheduled items: 4',
-          'Active runloops: YES',
-        ],
-        ['foo: bar', 'ding: bat']
-      )
     );
   });
 });

--- a/tests/unit/test-debug-info-test.js
+++ b/tests/unit/test-debug-info-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { run } from '@ember/runloop';
-import TestDebugInfo from 'ember-qunit/-internal/test-debug-info';
+import TestDebugInfo, { getSummary } from 'ember-qunit/-internal/test-debug-info';
 import getDebugInfoAvailable from 'ember-qunit/-internal/get-debug-info-available';
 import MockStableError, { overrideError, resetError } from './utils/mock-stable-error';
 import { randomBoolean, getSettledState, debugInfo } from './utils/test-isolation-helpers';
@@ -130,4 +130,33 @@ module('TestDebugInfo', function() {
       });
     });
   }
+
+  test('toString correctly prints minimal information', function(assert) {
+    assert.expect(1);
+
+    let testDebugInfo = new TestDebugInfo('foo', 'bar', getSettledState());
+
+    assert.equal(testDebugInfo.toString(), getSummary('foo: bar', []));
+  });
+
+  test('toString correctly prints all information', function(assert) {
+    assert.expect(1);
+
+    let testDebugInfo = new TestDebugInfo(
+      'foo',
+      'bar',
+      getSettledState(true, true, true, true, 2),
+      debugInfo
+    );
+
+    assert.equal(
+      testDebugInfo.toString(),
+      getSummary('foo: bar', [
+        'Pending AJAX requests: 2',
+        'Pending test waiters: YES',
+        'Pending timers: 2',
+        'Active runloops: YES',
+      ])
+    );
+  });
 });


### PR DESCRIPTION
There were two issues discovered with test-isolation-validation:

1. The use of `Error` when triggering the failure caused an infinite recursive state by always pushing a new test in the test queue
2. The test output sucked :)

![test-isolation-validation](https://user-images.githubusercontent.com/180990/48214625-32cf0500-e335-11e8-9cf7-76a40636c3d0.png)
