### PR TITLE
Added additional condition for when done callbacks are invoked

### DIFF
--- a/addon-test-support/ember-qunit/adapter.js
+++ b/addon-test-support/ember-qunit/adapter.js
@@ -25,6 +25,8 @@ function unhandledRejectionAssertion(current, error) {
   });
 }
 
+export function nonTestDoneCallback() {}
+
 let Adapter = Ember.Test.Adapter.extend({
   init() {
     this.doneCallbacks = [];
@@ -32,17 +34,25 @@ let Adapter = Ember.Test.Adapter.extend({
   },
 
   asyncStart() {
-    this.doneCallbacks.push(
-      this.qunit.config.current && this.qunit.config.current.assert
-        ? this.qunit.config.current.assert.async()
-        : null
-    );
+    let currentTest = this.qunit.config.current;
+    let done = currentTest && currentTest.assert ? currentTest.assert.async() : nonTestDoneCallback;
+    this.doneCallbacks.push({ test: currentTest, done });
   },
 
   asyncEnd() {
-    let done = this.doneCallbacks.pop();
-    // This can be null if asyncStart() was called outside of a test
-    if (done) {
+    let currentTest = this.qunit.config.current;
+
+    if (this.doneCallbacks.length === 0) {
+      throw new Error(
+        'Adapter asyncEnd called when no async was expected. Please create an issue in ember-qunit.'
+      );
+    }
+
+    let { test, done } = this.doneCallbacks.pop();
+
+    // In future, we should explore fixing this at a different level, specifically
+    // addressing the pairing of asyncStart/asyncEnd behavior in a more consistent way.
+    if (test === currentTest) {
       done();
     }
   },

--- a/addon-test-support/ember-qunit/index.js
+++ b/addon-test-support/ember-qunit/index.js
@@ -1,7 +1,7 @@
 export { default as moduleFor } from './legacy-2-x/module-for';
 export { default as moduleForComponent } from './legacy-2-x/module-for-component';
 export { default as moduleForModel } from './legacy-2-x/module-for-model';
-export { default as QUnitAdapter } from './adapter';
+export { default as QUnitAdapter, nonTestDoneCallback } from './adapter';
 export { module, test, skip, only, todo } from 'qunit';
 export { loadTests } from './test-loader';
 

--- a/tests/unit/utils/patch-assert-helper.js
+++ b/tests/unit/utils/patch-assert-helper.js
@@ -12,4 +12,13 @@ export default function patchAssert(assert) {
     resultInfo.message = `Failed: ${resultInfo.message}`;
     this._originalPushResult(resultInfo);
   };
+
+  assert.test.pushFailure = function(message, source, actual) {
+    this.pushResult({
+      result: true,
+      message: message || 'error',
+      actual: actual || null,
+      source,
+    });
+  };
 }


### PR DESCRIPTION
The `asyncStart` call stashes any `done` callbacks that are queued up for a particular test. Once the test is nearing completion, the `asyncEnd` call is invoked, which flushes the existing `done` callbacks, signaling test async completion. 

It was possible to get into a situation where, when a prior test returns a rejected promise, the `asyncEnd` would not be called. This, combined with the fact that `asyncEnd` wasn't ensuring the true test that owned the `done` callback was still the current test, would result in the `done` callback of the previous test being called for a different test.

This change fixes this situation.