### PR TITLE
Deprecate legacy test APIs

### DIFF
--- a/addon-test-support/ember-qunit/legacy-2-x/module-for-component.js
+++ b/addon-test-support/ember-qunit/legacy-2-x/module-for-component.js
@@ -1,6 +1,16 @@
 import { createModule } from './qunit-module';
 import { TestModuleForComponent } from 'ember-test-helpers';
+import { deprecate } from '@ember/application/deprecations';
 
 export default function moduleForComponent(name, description, callbacks) {
   createModule(TestModuleForComponent, name, description, callbacks);
+  deprecate(
+    `The usage "moduleForComponent" is deprecated. Please migrate the "${name}" module to use "setupRenderingTest".`,
+    false,
+    {
+      id: 'ember-qunit.deprecate-legacy-apis',
+      until: '5.0.0',
+      url: 'https://github.com/emberjs/ember-qunit/blob/master/docs/migration.md',
+    }
+  );
 }

--- a/addon-test-support/ember-qunit/legacy-2-x/module-for-model.js
+++ b/addon-test-support/ember-qunit/legacy-2-x/module-for-model.js
@@ -1,6 +1,16 @@
 import { createModule } from './qunit-module';
 import { TestModuleForModel } from 'ember-test-helpers';
+import { deprecate } from '@ember/application/deprecations';
 
 export default function moduleForModel(name, description, callbacks) {
+  deprecate(
+    `The usage "moduleForModel" is deprecated. Please migrate the "${name}" module to the new test APIs.`,
+    false,
+    {
+      id: 'ember-qunit.deprecate-legacy-apis',
+      until: '5.0.0',
+      url: 'https://github.com/emberjs/ember-qunit/blob/master/docs/migration.md',
+    }
+  );
   createModule(TestModuleForModel, name, description, callbacks);
 }

--- a/addon-test-support/ember-qunit/legacy-2-x/module-for.js
+++ b/addon-test-support/ember-qunit/legacy-2-x/module-for.js
@@ -1,6 +1,16 @@
 import { createModule } from './qunit-module';
 import { TestModule } from 'ember-test-helpers';
+import { deprecate } from '@ember/application/deprecations';
 
 export default function moduleFor(name, description, callbacks) {
+  deprecate(
+    `The usage "moduleFor" is deprecated. Please migrate the "${name}" module to use "module"`,
+    false,
+    {
+      id: 'ember-qunit.deprecate-legacy-apis',
+      until: '5.0.0',
+      url: 'https://github.com/emberjs/ember-qunit/blob/master/docs/migration.md',
+    }
+  );
   createModule(TestModule, name, description, callbacks);
 }


### PR DESCRIPTION
This deprecates the `moduleFor`, `moduleForComponent` and `moduleForModel` APIs. This implements the [deprecation section](https://github.com/emberjs/rfcs/blob/master/text/0232-simplify-qunit-testing-api.md#deprecate-older-apis) of [RFC#232](https://github.com/emberjs/rfcs/blob/master/text/0232-simplify-qunit-testing-api.md).