### PR TITLE
Work around issue with pauseTest() timing out.

### DIFF
--- a/addon-test-support/ember-qunit/index.js
+++ b/addon-test-support/ember-qunit/index.js
@@ -34,6 +34,11 @@ export function setupTest(hooks, _options) {
       this.pauseTest = function QUnit_pauseTest() {
         assert.timeout(-1); // prevent the test from timing out
 
+        // This is a temporary work around for
+        // https://github.com/emberjs/ember-qunit/issues/496 this clears the
+        // timeout that would fail the test when it hits the global testTimeout
+        // value.
+        clearTimeout(QUnit.config.timeout);
         return originalPauseTest.call(this);
       };
     });


### PR DESCRIPTION
Rough summary of the issue that this is solving is that when the test is an async function setting `assert.timeout(-1)` _essentially_ has no effect.

See detailed explanation in https://github.com/emberjs/ember-qunit/issues/496#issuecomment-493224302.

---

Tested locally by:

* setting `QUnit.config.testTimeout` to `10`
* add `await this.pauseTest()` to [can render a simple template](https://github.com/emberjs/ember-qunit/blob/489d4d69b7360e3b4c26beea67d6728afdc47536/tests/integration/setup-rendering-test-test.js#L21) test
* confirm that `can render a simple template` fails without modifications
* add these changes
* confirm test waits indefinitely

Works around issue reported in https://github.com/emberjs/ember-qunit/issues/496.