### PR TITLE
Add a small configurable delay to test isolation validation assertion.

### DIFF
--- a/addon-test-support/ember-qunit/index.js
+++ b/addon-test-support/ember-qunit/index.js
@@ -165,10 +165,10 @@ export function setupResetOnerror() {
   QUnit.testDone(resetOnerror);
 }
 
-export function setupTestIsolationValidation() {
+export function setupTestIsolationValidation(delay) {
   waitForSettled = false;
   run.backburner.DEBUG = true;
-  QUnit.on('testStart', installTestNotIsolatedHook);
+  QUnit.on('testStart', () => installTestNotIsolatedHook(delay));
 }
 
 /**
@@ -188,6 +188,10 @@ export function setupTestIsolationValidation() {
    of `Ember.onerror` will be disabled.
    @param {Boolean} [options.setupTestIsolationValidation] If `false` test isolation validation
    will be disabled.
+   @param {Number} [options.testIsolationValidationDelay] When using
+   setupTestIsolationValidation this number represents the maximum amount of
+   time in milliseconds that is allowed _after_ the test is completed for all
+   async to have been completed. The default value is 50.
  */
 export function start(options = {}) {
   if (options.loadTests !== false) {
@@ -214,7 +218,7 @@ export function start(options = {}) {
     typeof options.setupTestIsolationValidation !== 'undefined' &&
     options.setupTestIsolationValidation !== false
   ) {
-    setupTestIsolationValidation();
+    setupTestIsolationValidation(options.testIsolationValidationDelay);
   }
 
   if (options.startTests !== false) {

--- a/tests/unit/test-isolation-validation-test.js
+++ b/tests/unit/test-isolation-validation-test.js
@@ -55,6 +55,13 @@ if (getDebugInfo()) {
       isWaiterPending = true;
     });
 
+    test('detectIfTestNotIsolated allows for a small window (e.g. an autorun to flush)', function(assert) {
+      assert.expect(0);
+
+      isWaiterPending = true;
+      setTimeout(() => (isWaiterPending = false), 0);
+    });
+
     module('timeouts', function(hooks) {
       hooks.afterEach(function(assert) {
         assert.test._originalPushResult({


### PR DESCRIPTION
Recent changes to Ember (for the `@tracked` feature in Octane) make it so that an autorun is much more commonly present. In those cases any operation using `run.join` that would have previously been sync (because no autorun existed when `run.join` was invoked) will now flush asynchronously. In this case we will only have a single autorun scheduled (which would resolve on the next microtask queue flush), but it would be enough to "trip up" the test isolation validation system.

With this change to the test isolation validation infrastructure we allow a small delay for the test to "settle" before doing the assertion.  This change makes it possible for many more applications and addons to take advantage of the protections that test isolation validation provides without incurring frustrating to track down timing issues outside of the applications own control.

Closes #478.