### PR TITLE
task(engine): Bumping minimum supported node version to 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "6"
+  - "8"
 
 addons:
   chrome: stable

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "prettier": "1.18.2"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "8.* || >= 10.*"
   },
   "changelog": {
     "repo": "emberjs/ember-qunit",


### PR DESCRIPTION
Fixes CI by updating minimum supported node version to 8. Will require a major version bump.