### PR TITLE
prevent leakage of position fixed elements from the testing container

### DIFF
--- a/vendor/ember-qunit/test-container-styles.css
+++ b/vendor/ember-qunit/test-container-styles.css
@@ -9,6 +9,8 @@
   z-index: 98;
   border: 1px solid #ccc;
   margin: 0 auto;
+
+  /* Prevent leaking position fixed elements outside the testing container */
   transform: translateZ(0);
 }
 

--- a/vendor/ember-qunit/test-container-styles.css
+++ b/vendor/ember-qunit/test-container-styles.css
@@ -9,6 +9,7 @@
   z-index: 98;
   border: 1px solid #ccc;
   margin: 0 auto;
+  transform: translateZ(0);
 }
 
 #ember-testing-container.full-screen {


### PR DESCRIPTION
Having recently worked on an app with a lot of `position: fixed` present I got annoyed by everything visually leaking from the `#ember-testing-container` element. This cool trick prevents that from happening and keeps everything where it should be.

Per W3 spec ( https://www.w3.org/TR/css-transforms-1/#transform-rendering ):

> For elements whose layout is governed by the CSS box model, any value other than none for the transform property also causes the element to establish a containing block for all descendants. Its padding box will be used to layout for all of its absolute-position descendants, fixed-position descendants, and descendant fixed background attachments.