### PR TITLE
Use checkerboard pattern for testing container background

### DIFF
--- a/vendor/ember-qunit/test-container-styles.css
+++ b/vendor/ember-qunit/test-container-styles.css
@@ -1,6 +1,13 @@
 #ember-testing-container {
   position: relative;
-  background: white;
+
+  background-color: #fff;
+  background-image:
+    linear-gradient(45deg, #eee 25%, transparent 25%, transparent 75%, #eee 75%, #eee),
+    linear-gradient(45deg, #eee 25%, transparent 25%, transparent 75%, #eee 75%, #eee);
+  background-position: 0 0, 10px 10px;
+  background-size: 20px 20px;
+
   bottom: 0;
   right: 0;
   width: 640px;


### PR DESCRIPTION
This changes the default background of the `#ember-testing-container` from purely white to a slight checkerboard pattern to make it more obvious what rendered components have a transparent vs. a white background.

![Bildschirmfoto 2019-12-12 um 16 16 55](https://user-images.githubusercontent.com/141300/70725326-76e0c600-1cfc-11ea-83b3-6a35498fb856.png)

the pattern code is taken from see https://leaverou.github.io/css3patterns/#checkerboard
