### PR TITLE
Update README capabilities for Node engine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ helpers contained in
 Requirements
 ------------------------------------------------------------------------------
 
-- Node.js 6 or above
+- Node.js 10 or above
 - Ember 3.8 or above
 - Ember CLI 2.13 or above
 


### PR DESCRIPTION
Dropped Node 6 and 8 in #616, but missed updating the README.