### PR TITLE
Require project to provide `@ember/test-helpers` and `qunit`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,15 +28,16 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "@ember/test-helpers": "^1.7.1",
     "broccoli-funnel": "^3.0.3",
     "broccoli-merge-trees": "^3.0.2",
     "common-tags": "^1.4.0",
     "ember-cli-babel": "^7.22.1",
     "ember-cli-test-loader": "^3.0.0",
-    "qunit": "^2.10.1"
+    "ember-cli-version-checker": "^5.1.1",
+    "silent-error": "^1.1.1"
   },
   "devDependencies": {
+    "@ember/test-helpers": "^1.7.1",
     "ember-cli": "~3.20.0",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-htmlbars": "^5.2.0",
@@ -57,8 +58,13 @@
     "lerna-changelog": "^1.0.1",
     "loader.js": "^4.2.3",
     "prettier": "2.0.5",
+    "qunit": "^2.10.1",
     "release-it": "^13.6.6",
     "release-it-lerna-changelog": "^2.3.0"
+  },
+  "peerDependencies": {
+    "@ember/test-helpers": "^1.7.1",
+    "qunit": "^2.10.1"
   },
   "engines": {
     "node": "10.* || >= 12.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4612,6 +4612,15 @@ ember-cli-version-checker@^5.0.2:
     semver "^7.1.3"
     silent-error "^1.1.1"
 
+ember-cli-version-checker@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-5.1.1.tgz#3185c526c14671609cbd22ab0d0925787fc84f3d"
+  integrity sha512-YziSW1MgOuVdJSyUY2CKSC4vXrGQIHF6FgygHkJOxYGjZNQYwf5MK0sbliKatvJf7kzDSnXs+r8JLrD74W/A8A==
+  dependencies:
+    resolve-package-path "^2.0.0"
+    semver "^7.3.2"
+    silent-error "^1.1.1"
+
 ember-cli@~3.20.0:
   version "3.20.0"
   resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-3.20.0.tgz#729c62ce0cb2804237155886619acc54c77255dc"


### PR DESCRIPTION
This moves `@ember/test-helpers` and `qunit` from `dependencies` to `peerDependencies`, and ensures those peer dependencies are satisfied by the host application.

This allows the host application to control the precise `@ember/test-helpers` and `qunit` versions, and better positions our users to leverage Embroider/ember-auto-import style "automatic" imports.

Also to note, `npm@7` will aid us here and ensure that peer dependencies are installed.