### PR TITLE
Require host to provide testing fixture DOM elements.

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,23 +73,6 @@ module.exports = {
     return this._targetOptions;
   },
 
-  contentFor: function (type) {
-    // Skip if insertContentForTestBody === false.
-    if (
-      type === 'test-body' &&
-      !(this.targetOptions().insertContentForTestBody === false)
-    ) {
-      return stripIndent`
-        <div id="qunit"></div>
-        <div id="qunit-fixture"></div>
-
-        <div id="ember-testing-container">
-          <div id="ember-testing"></div>
-        </div>
-      `;
-    }
-  },
-
   treeForVendor: function (tree) {
     const MergeTrees = require('broccoli-merge-trees');
     const Funnel = require('broccoli-funnel');

--- a/tests/index.html
+++ b/tests/index.html
@@ -19,7 +19,14 @@
   </head>
   <body>
     {{content-for "body"}}
-    {{content-for "test-body"}}
+
+    <div id="qunit"></div>
+    <div id="qunit-fixture">
+      <div id="ember-testing-container">
+        <div id="ember-testing"></div>
+      </div>
+    </div>
+
 
     <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>


### PR DESCRIPTION
Instead of `ember-qunit` automatically injecting some DOM elements into `test-body` (via the `contentFor` hook) this requires the project itself to add these DOM elements.

This dove tails with the changes to make `qunit` a peer dependency as this now puts the app in full control of the testing fixtures.

See:

* https://github.com/emberjs/ember-test-helpers/pull/911
* https://github.com/emberjs/ember-test-helpers/pull/910
* #738