### PR TITLE
Refactor peerDependencies validation check.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "common-tags": "^1.8.0",
     "ember-cli-babel": "^7.22.1",
     "ember-cli-test-loader": "^3.0.0",
-    "ember-cli-version-checker": "^5.1.1",
+    "semver": "^7.3.2",
     "silent-error": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Using `ember-cli-version-checker` for this will not work, since that only checks Ember addons (and `qunit` is not an addon).