### PR TITLE
Update to `@ember/test-helpers@2.0.0-beta.6` minimum version.

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -12,9 +12,7 @@ import {
   setupContext,
   teardownContext,
   setupRenderingContext,
-  teardownRenderingContext,
   setupApplicationContext,
-  teardownApplicationContext,
   validateErrorHandler,
 } from '@ember/test-helpers';
 import { installTestNotIsolatedHook } from './test-isolation-validation';
@@ -62,10 +60,6 @@ export function setupRenderingTest(hooks, _options) {
   hooks.beforeEach(function () {
     return setupRenderingContext(this);
   });
-
-  hooks.afterEach(function () {
-    return teardownRenderingContext(this, options);
-  });
 }
 
 export function setupApplicationTest(hooks, _options) {
@@ -78,10 +72,6 @@ export function setupApplicationTest(hooks, _options) {
 
   hooks.beforeEach(function () {
     return setupApplicationContext(this);
-  });
-
-  hooks.afterEach(function () {
-    return teardownApplicationContext(this, options);
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "silent-error": "^1.1.1"
   },
   "devDependencies": {
-    "@ember/test-helpers": "^2.0.0-beta.4",
+    "@ember/test-helpers": "^2.0.0-beta.6",
     "babel-eslint": "^10.1.0",
     "ember-cli": "~3.20.0",
     "ember-cli-dependency-checker": "^3.2.0",
@@ -65,7 +65,7 @@
     "release-it-lerna-changelog": "^2.3.0"
   },
   "peerDependencies": {
-    "@ember/test-helpers": "^2.0.0-beta.4",
+    "@ember/test-helpers": "^2.0.0-beta.6",
     "qunit": "^2.11.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -922,16 +922,17 @@
   resolved "https://registry.yarnpkg.com/@ember/edition-utils/-/edition-utils-1.2.0.tgz#a039f542dc14c8e8299c81cd5abba95e2459cfa6"
   integrity sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog==
 
-"@ember/test-helpers@^2.0.0-beta.4":
-  version "2.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.0.0-beta.4.tgz#61134f12d7607a572c32841cf9d2a52bda6c11ac"
-  integrity sha512-cjToCr0RAbfuZGvmu5apZjCd9E4XBEg+afBbTqHA8eRqzToe82Jso8b3YnzqMRc5OVURI2c6JhGwNbO+Aj8zlw==
+"@ember/test-helpers@^2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.0.0-beta.6.tgz#47d9e56b963595d8303df90d7bdd085497f1b006"
+  integrity sha512-H+HcDLtzuHCUJxt2vG3T5lfnQUkuVkPJIPLVN/1LVzthnVxPOV9are3D5wilSD7Rtq0cgSTU71QqQ6e0Lmm9IQ==
   dependencies:
     "@ember/test-waiters" "^2.2.0"
     broccoli-debug "^0.6.5"
     broccoli-funnel "^3.0.3"
     ember-cli-babel "^7.22.1"
     ember-cli-htmlbars "^5.2.0"
+    ember-destroyable-polyfill "^2.0.1"
 
 "@ember/test-waiters@^2.2.0":
   version "2.2.0"
@@ -1593,6 +1594,13 @@ babel-eslint@^10.1.0:
     "@babel/types" "^7.7.0"
     eslint-visitor-keys "^1.0.0"
     resolve "^1.12.0"
+
+babel-plugin-debug-macros@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz#0120ac20ce06ccc57bf493b667cf24b85c28da7a"
+  integrity sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==
+  dependencies:
+    semver "^5.3.0"
 
 babel-plugin-debug-macros@^0.3.3:
   version "0.3.3"
@@ -3278,6 +3286,14 @@ ember-cli-typescript@^3.1.3:
     stagehand "^1.0.0"
     walk-sync "^2.0.0"
 
+ember-cli-version-checker@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz#47771b731fe0962705e27c8199a9e3825709f3b3"
+  integrity sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==
+  dependencies:
+    resolve "^1.3.3"
+    semver "^5.3.0"
+
 ember-cli-version-checker@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz#7c9b4f5ff30fdebcd480b1c06c4de43bb51c522c"
@@ -3398,6 +3414,24 @@ ember-cli@~3.20.0:
     walk-sync "^2.2.0"
     watch-detector "^1.0.0"
     yam "^1.0.0"
+
+ember-compatibility-helpers@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.1.tgz#87c92c4303f990ff455c28ca39fb3ee11441aa16"
+  integrity sha512-6wzYvnhg1ihQUT5yGqnLtleq3Nv5KNv79WhrEuNU9SwR4uIxCO+KpyC7r3d5VI0EM7/Nmv9Nd0yTkzmTMdVG1A==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^2.1.1"
+    semver "^5.4.1"
+
+ember-destroyable-polyfill@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.1.tgz#391cd95a99debaf24148ce953054008d00f151a6"
+  integrity sha512-hyK+/GPWOIxM1vxnlVMknNl9E5CAFVbcxi8zPiM0vCRwHiFS8Wuj7PfthZ1/OFitNNv7ITTeU8hxqvOZVsrbnQ==
+  dependencies:
+    ember-cli-babel "^7.22.1"
+    ember-cli-version-checker "^5.1.1"
+    ember-compatibility-helpers "^1.2.1"
 
 ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"
@@ -7612,7 +7646,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==


### PR DESCRIPTION
In 2.0.0-beta.6 the `teardownRenderingContext` and `teardownApplicationContext` methods were removed (as they are no longer needed). This updates to accomodate that.