### PR TITLE
Correct invalid QUnit imports.

### DIFF
--- a/addon-test-support/adapter.js
+++ b/addon-test-support/adapter.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import QUnit from 'qunit';
+import * as QUnit from 'qunit';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 function unhandledRejectionAssertion(current, error) {

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -14,7 +14,7 @@ import { assign } from '@ember/polyfills';
 import { resetOnerror, getTestMetadata } from '@ember/test-helpers';
 import { loadTests } from './test-loader';
 import Ember from 'ember';
-import QUnit from 'qunit';
+import * as QUnit from 'qunit';
 import QUnitAdapter from './adapter';
 import {
   setupContext,

--- a/addon-test-support/qunit-configuration.js
+++ b/addon-test-support/qunit-configuration.js
@@ -1,4 +1,4 @@
-import QUnit from 'qunit';
+import * as QUnit from 'qunit';
 
 QUnit.config.autostart = false;
 QUnit.config.urlConfig.push({ id: 'nocontainer', label: 'Hide container' });

--- a/addon-test-support/test-isolation-validation.js
+++ b/addon-test-support/test-isolation-validation.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import QUnit from 'qunit';
+import * as QUnit from 'qunit';
 import { run } from '@ember/runloop';
 import { waitUntil, isSettled, getSettledState } from '@ember/test-helpers';
 import { getDebugInfo } from '@ember/test-helpers';

--- a/addon-test-support/test-loader.js
+++ b/addon-test-support/test-loader.js
@@ -1,4 +1,4 @@
-import QUnit from 'qunit';
+import * as QUnit from 'qunit';
 import AbstractTestLoader, {
   addModuleExcludeMatcher,
   addModuleIncludeMatcher,


### PR DESCRIPTION
Using `import QUnit from 'qunit';` is _actually_ invalid. There **is no** default export from QUnit itself. The way this was working is that it has been relying on `loader.js`'s behavior when a module does not include a default export (it makes `moduleExports.default = moduleExports`).