### PR TITLE
Fix usage within applications that do not have ember-auto-import.

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,9 +115,12 @@ module.exports = {
 
     const Funnel = require('broccoli-funnel');
 
-    let babel = this.addons.find((a) => a.name === 'ember-cli-babel');
+    let scopedInputTree = new Funnel(tree, { destDir: 'ember-qunit' });
 
-    return babel.transpileTree(new Funnel(tree, { destDir: 'ember-qunit' }));
+    return this.preprocessJs(scopedInputTree, '/', this.name, {
+      annotation: `processedAddonJsFiles(${this.name})`,
+      registry: this.registry,
+    });
   },
 
   setTestGenerator: function () {


### PR DESCRIPTION
Without this change (e.g. in `ember-qunit@5.0.0-beta.3`) applications that do **not** have `ember-auto-import` as dependencies themselves _or_ do not have a direct import of `qunit` somewhere in their own code would simply never have `QUnit` defined.