### PR TITLE
Migrate to validate-peer-dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "ember-auto-import": "^1.6.0",
     "ember-cli-babel": "^7.22.1",
     "ember-cli-test-loader": "^3.0.0",
-    "resolve-package-path": "^2.0.0",
-    "semver": "^7.3.2",
-    "silent-error": "^1.1.1"
+    "resolve-package-path": "^3.1.0",
+    "silent-error": "^1.1.1",
+    "validate-peer-dependencies": "^1.0.0"
   },
   "devDependencies": {
     "@ember/test-helpers": "^2.0.0-beta.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9852,6 +9852,14 @@ resolve-package-path@^2.0.0:
     path-root "^0.1.1"
     resolve "^1.13.1"
 
+resolve-package-path@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/resolve-package-path/-/resolve-package-path-3.1.0.tgz#35faaa5d54a9c7dd481eb7c4b2a44410c9c763d8"
+  integrity sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==
+  dependencies:
+    path-root "^0.1.1"
+    resolve "^1.17.0"
+
 resolve-path@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve-path/-/resolve-path-1.4.0.tgz#c4bda9f5efb2fce65247873ab36bb4d834fe16f7"
@@ -11433,6 +11441,14 @@ validate-npm-package-name@^3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
+
+validate-peer-dependencies@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/validate-peer-dependencies/-/validate-peer-dependencies-1.0.0.tgz#d82f1c2020eef96d331723c2cef15de94063adf3"
+  integrity sha512-9T1pR9gopOuQYDMT0ApUPiRt1MOsSCJUm56mr55Hy7RDx7dyFHa6SnEXVP5wJuFyJ8pWyZoYxfFo4raEspRbUg==
+  dependencies:
+    resolve-package-path "^3.1.0"
+    semver "^7.3.2"
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This migrates to using [validate-peer-dependencies](https://github.com/rwjblue/validate-peer-dependencies) It  was extracted (and improved) from this original code, and is in use in a few other libraries.
