### PR TITLE
Add `fullscreencontainer` query param (similar to `devmode` but does not modify test timeout)

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -87,9 +87,10 @@ export function setupApplicationTest(hooks, _options) {
    Uses current URL configuration to setup the test container.
 
    * If `?nocontainer` is set, the test container will be hidden.
-   * If `?dockcontainer` or `?devmode` are set the test container will be
-     absolutely positioned.
-   * If `?devmode` is set, the test container will be made full screen.
+   * If `?dockcontainer`, `?fullscreencontainer` or `?devmode` are set the test
+     container will be absolutely positioned.
+   * If `?devmode` or `?fullscreencontainer` is set, the test container will be
+     made full screen.
 
    @method setupTestContainer
  */
@@ -103,9 +104,11 @@ export function setupTestContainer() {
 
   let containerVisibility = params.nocontainer ? 'hidden' : 'visible';
   let containerPosition =
-    params.dockcontainer || params.devmode ? 'fixed' : 'relative';
+    params.dockcontainer || params.devmode || params.fullscreencontainer
+      ? 'fixed'
+      : 'relative';
 
-  if (params.devmode) {
+  if (params.devmode || params.fullscreencontainer) {
     testContainer.className = ' full-screen';
   }
 


### PR DESCRIPTION
As mentioned in https://github.com/emberjs/ember-qunit/issues/595#issuecomment-714514126, this adds a `fullscreencontainer` query param that does exactly what `devmode` does, minus removing the test timeout. 

This is useful for tests that depend on exact dimensions of elements (like scrolling an element to a certain position). An example: https://github.com/emberjs/ember-qunit/issues/521