### PR TITLE
Clarified migration guide to v5.x when a project includes QUnit DOM

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -18,17 +18,17 @@ Upgrading from v4.x to v5.0.0
 ### `qunit` and `@ember/test-helpers` dependencies
 
 Older versions of `ember-qunit` directly depended on `qunit` and
-`@ember/test-helpers`, in v5 this relationship was changed and now
-`ember-qunit` has `qunit` and `@ember/test-helpers` as peer dependencies.
+`@ember/test-helpers`. In v5, this relationship was changed and now
+`ember-qunit` has `qunit` and `@ember/test-helpers` (v2) as peer dependencies.
 
-In order to accomodate this change in your application you can run:
+In order to accomodate this change, in your application, you can run:
 
 ```sh
 # npm users
-npm install --save-dev qunit "@ember/test-helpers@^2.0.0-beta.4"
+npm install --save-dev qunit "@ember/test-helpers"
 
 # yarn users
-yarn add --dev qunit "@ember/test-helpers@^2.0.0-beta.4"
+yarn add --dev qunit "@ember/test-helpers"
 ```
 
 ### DOM fixtures

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -49,6 +49,28 @@ snippet to your `tests/index.html` just after your `{{content-for
 </div>
 ```
 
+### QUnit DOM
+
+If you use QUnit DOM, you may encounter the error message `assert.dom is not a function` when you run tests.
+
+To address this issue, import and run QUnit DOM's `setup` function in your `test-helper.js` file:
+
+```javascript
+// tests/test-helper.js
+import * as QUnit from 'qunit';
+import { setup } from 'qunit-dom';
+
+//...
+
+setup(QUnit.assert);
+
+setApplication(Application.create(config.APP));
+
+start();
+
+//...
+```
+
 ### Remove `ember-test-helpers` modules
 
 For a long time `@ember/test-helpers` re-exported all of its modules under the `ember-test-helpers` namespace,


### PR DESCRIPTION
## Description

I tried upgrading `ember-qunit` to `v5.1` in a production app today. I followed the migration guide by installing `qunit` and `@ember/test-helpers` and updating `tests/index.html`.

When I ran tests afterwards with `ember t -s`, I encountered the error message `assert.dom is not a function` in all tests that relied on QUnit DOM assertions. From the migration guide, I didn't realize there were extra step(s) for QUnit DOM.

I updated the migration guide by copy-pasting the code snippet from [QUnit DOM's migration guide](https://github.com/simplabs/qunit-dom#ember-projects-using-ember-qunit-v5x-and-above), then linking to the page in case there may be additional content in the future.