### PR TITLE
Add treeType annotation to hint test-support to ember-auto-import.

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ module.exports = {
     return this.preprocessJs(scopedInputTree, '/', this.name, {
       annotation: `ember-qunit - treeForAddonTestSupport`,
       registry: this.registry,
+      treeType: 'addon-test-support',
     });
   },
 


### PR DESCRIPTION
Provides information to ember-auto-import so that it can know what the correct target asset should be.

References:

* https://github.com/ef4/ember-auto-import/pull/329
* https://github.com/ember-cli/ember-cli/pull/9411
* https://github.com/emberjs/ember-test-helpers/pull/963
