### PR TITLE
Fixes testing container layout issues for QUnit 2.14

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -87,8 +87,6 @@ export function setupApplicationTest(hooks, _options) {
    Uses current URL configuration to setup the test container.
 
    * If `?nocontainer` is set, the test container will be hidden.
-   * If `?dockcontainer`, `?fullscreencontainer` or `?devmode` are set the test
-     container will be absolutely positioned.
    * If `?devmode` or `?fullscreencontainer` is set, the test container will be
      made full screen.
 
@@ -101,26 +99,13 @@ export function setupTestContainer() {
   }
 
   let params = QUnit.urlParams;
-
   let containerVisibility = params.nocontainer ? 'hidden' : 'visible';
-  let containerPosition =
-    params.dockcontainer || params.devmode || params.fullscreencontainer
-      ? 'fixed'
-      : 'relative';
 
   if (params.devmode || params.fullscreencontainer) {
     testContainer.className = ' full-screen';
   }
 
   testContainer.style.visibility = containerVisibility;
-  testContainer.style.position = containerPosition;
-
-  let qunitContainer = document.getElementById('qunit');
-  if (params.dockcontainer) {
-    qunitContainer.style.marginBottom = window.getComputedStyle(
-      testContainer
-    ).height;
-  }
 }
 
 /**

--- a/addon-test-support/qunit-configuration.js
+++ b/addon-test-support/qunit-configuration.js
@@ -3,7 +3,6 @@ import * as QUnit from 'qunit';
 QUnit.config.autostart = false;
 QUnit.config.urlConfig.push({ id: 'nocontainer', label: 'Hide container' });
 QUnit.config.urlConfig.push({ id: 'nolint', label: 'Disable Linting' });
-QUnit.config.urlConfig.push({ id: 'dockcontainer', label: 'Dock container' });
 QUnit.config.urlConfig.push({ id: 'devmode', label: 'Development mode' });
 
 QUnit.config.testTimeout = QUnit.urlParams.devmode ? null : 60000; //Default Test Timeout 60 Seconds

--- a/vendor/ember-qunit/test-container-styles.css
+++ b/vendor/ember-qunit/test-container-styles.css
@@ -8,7 +8,7 @@
 }
 
 #ember-testing-container {
-  position: absolute;
+  position: fixed;
 
   background-color: #fff;
   background-image:
@@ -18,11 +18,9 @@
   background-size: 20px 20px;
 
   bottom: 0;
-  right: 5%;
-  width: 40%;
-  height: 35%;
-  max-width: 640px;
-  max-height: 384px;
+  right: 0;
+  width: 640px;
+  height: 384px;
   overflow: auto;
   z-index: 98;
   border: 1px solid #ccc;
@@ -38,12 +36,7 @@
   overflow: auto;
   z-index: 98;
   border: none;
-  max-height: none;
-  max-width: none;
   right: 0;
-  left: 0;
-  top: 0;
-  bottom: 0;
 }
 
 #ember-testing {
@@ -58,4 +51,20 @@
   width: 100%;
   height: 100%;
   transform: scale(1);
+}
+
+#qunit-tests > li:last-child {
+  margin-bottom: 384px;
+}
+
+@supports (display: flex) or (display: -webkit-box) {
+  @media (min-height: 500px) {
+    #qunit-tests {
+      overflow: auto;
+    }
+
+    #ember-testing-container {
+      right: 30px;
+    }
+  }
 }


### PR DESCRIPTION
This change attempts to address the numerous issues that have been introduced by the CSS positional updates in QUnit 2.14.0, including https://github.com/emberjs/ember-qunit/issues/793 and https://github.com/emberjs/ember-qunit/issues/801.  Besides visual layout problems, the relative percentage-based dimensions introduced in PR https://github.com/emberjs/ember-qunit/pull/786/ have been found to cause random test failures in existing applications, especially those which assert visibility states. The modifications did not consider that the ember testing container resides in qunit's fixture for v5. These have also been found to cause `ember-a11y-testing` failures with false-positives/negatives.

Given that the QUnit layout is now `position: fixed` based, it is no longer possible for the testing container to fall directly below the test results. As such, the container now also requires fixed positioning in relation to the viewport, similar to the "docked container" layout.

To follow the convention applied in https://github.com/qunitjs/qunit/pull/1513/files, the proposed fixes ensure that the UI reverts to the old layouts if the browser doesn't support CSS `flex` display, or the viewport height is constricted below the 500px threshold. Percentage based dimensions have been reverted back to fixed pixels to prevent testing container jank and false-positive/negative failures mentioned above. I've iterated over a bunch of different ways of remediating these problems, and believe this is probably the most balanced approach between usability and not having to override a bunch of QUnit's styling.

For the default layout, the proposed fix pins the testing container to the bottom of the viewport and centered, essentially dividing the screen into two horizontal panes with some semblance of the old layout.

Default view:
![image](https://user-images.githubusercontent.com/945868/107805308-037c7f00-6d1a-11eb-86b2-45e021df84fe.png)
Test results scrolled to bottom:
![image](https://user-images.githubusercontent.com/945868/107805477-43dbfd00-6d1a-11eb-8a3d-21117df16b76.png)

Viewport below 500px height (or lack of `flex` support) reverts back to old layout.
Top:
![image](https://user-images.githubusercontent.com/945868/107805982-01ff8680-6d1b-11eb-8faa-fb1b9a67cfb4.png)
Bottom:
![image](https://user-images.githubusercontent.com/945868/107805992-062ba400-6d1b-11eb-89a1-4c86522fc37b.png)

The "docked container" option pretty much remains similar and pins the testing container to the bottom right side of the screen.

Default view:
![image](https://user-images.githubusercontent.com/945868/107806211-615d9680-6d1b-11eb-87b5-a2e01a797861.png)

Test results scrolled to bottom:
![image](https://user-images.githubusercontent.com/945868/107806241-6ae6fe80-6d1b-11eb-9997-e5b56a50f31b.png)

Height constriction (or lack of `flex` support) reverts to old layout
![image](https://user-images.githubusercontent.com/945868/107806259-70444900-6d1b-11eb-9db2-fd4f1d45cacf.png)
![image](https://user-images.githubusercontent.com/945868/107806273-74706680-6d1b-11eb-995c-21b3913cc146.png)

Dev mode:
<img width="1272" alt="Screen Shot 2021-02-12 at 11 24 24 AM" src="https://user-images.githubusercontent.com/945868/107813024-00d35700-6d25-11eb-821b-0516fa768cfb.png">

Notable items:
- Since the percentage-based dimensions have been removed, the fixes applied in PR https://github.com/emberjs/ember-qunit/pull/804/ are no longer necessary as "full screen" mode works as expected.
- These changes require a new qualifier to differentiate between standard layout and "docked container" layout, hence the addition of the `docked-container` CSS class to the `body`.
- Theoretically, these changes are backportable to v.4.0.x.
- To simplify things, we may want to consider making the "docked container" layout the new default and remove it as a selectable option from the UI altogether.
- These changes still require some testing in various browser permutations, and also verification in real applications. But, I think we're in a good enough state to open it up for discussion.