### PR TITLE
Relax peer dependency minimums to ember-qunit@5.0.0 versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
     "release-it-lerna-changelog": "^3.1.0"
   },
   "peerDependencies": {
-    "@ember/test-helpers": "^2.2.3",
-    "qunit": "^2.14.0"
+    "@ember/test-helpers": "^2.1.0",
+    "qunit": "^2.13.0"
   },
   "engines": {
     "node": "10.* || 12.* || >= 14.*"


### PR DESCRIPTION
ember-qunit@5.0.0 shipped with `qunit: ^2.13.0` and `@ember/test-helpers: ^2.1.0`. However, when Dependabot landed a dependency update for our internal dev dependencies it also increased the minimum for the peerDep (in 719af61 and fd9fa19) both of which were released in ember-qunit@5.1.2.

Changing the minimum version of a peer dependency that we enforce (via `validatePeerDependencies`) should be considered a breaking change!

This reverts that change and sets the peer dependencies back to its value when 5.0.0 was published.