### PR TITLE
Fix Node 10 test stuff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
+        with:
+          node-version: 10.x
       - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn test:ember
@@ -28,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
+        with:
+          node-version: 10.x
       - run: yarn install --no-lockfile
       - run: yarn test:ember
 
@@ -57,7 +61,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
         with:
-          node-version: 14.x
+          node-version: 12.x
       - name: install dependencies
         run: yarn install --frozen-lockfile
       - name: test

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,7 +1,42 @@
 'use strict';
 
 const getChannelURL = require('ember-source-channel-url');
-const { embroiderSafe } = require('@embroider/test-setup');
+const EMBROIDER_VERSION = '^0.43.4';
+const embroider = {
+  safe: {
+    name: 'embroider-safe',
+    npm: {
+      devDependencies: {
+        '@embroider/core': EMBROIDER_VERSION,
+        '@embroider/webpack': EMBROIDER_VERSION,
+        '@embroider/compat': EMBROIDER_VERSION,
+
+        // Webpack is a peer dependency of `@embroider/webpack`
+        webpack: '^5.0.0',
+      },
+    },
+    env: {
+      EMBROIDER_TEST_SETUP_OPTIONS: 'safe',
+    },
+  },
+
+  optimized: {
+    name: 'embroider-optimized',
+    npm: {
+      devDependencies: {
+        '@embroider/core': EMBROIDER_VERSION,
+        '@embroider/webpack': EMBROIDER_VERSION,
+        '@embroider/compat': EMBROIDER_VERSION,
+
+        // Webpack is a peer dependency of `@embroider/webpack`
+        webpack: '^5.0.0',
+      },
+    },
+    env: {
+      EMBROIDER_TEST_SETUP_OPTIONS: 'optimized',
+    },
+  },
+};
 
 module.exports = async function () {
   return {
@@ -104,7 +139,20 @@ module.exports = async function () {
           devDependencies: {},
         },
       },
-      embroiderSafe(),
+      embroider.safe,
+      // disable embroider optimized test scenarios, as the dynamism these
+      // tests use is not compatible with embroider we are still exploring
+      // appropriate paths forward.
+      //
+      // Steps to re-enable:
+      //
+      // 1. have a strategy to make this work
+      // 2. uncomment the next line
+      // embroider.optimized,
+      //
+      // 3. add "embroider-optimized" to .github/workflows/ci-build.yml's
+      //    ember-try-scenario list.
+      //
       // embroiderOptimized(), disabled because of: https://github.com/embroider-build/embroider/issues/522
     ],
   };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -10,6 +10,16 @@ module.exports = function (defaults) {
     },
   });
 
-  const { maybeEmbroider } = require('@embroider/test-setup');
-  return maybeEmbroider(app);
+  try {
+    const { maybeEmbroider } = require('@embroider/test-setup'); // eslint-disable-line node/no-missing-require
+    return maybeEmbroider(app);
+  } catch (e) {
+    // This exists, so that we can continue to support node 10 for some of our
+    // test scenarios. Specifically those not scenario testing embroider. As
+    // @embroider/test-setup and @embroider in no longer supports node 10
+    if (e !== null && typeof e === 'object' && e.code === 'MODULE_NOT_FOUND') {
+      return app.toTree();
+    }
+    throw e;
+  }
 };

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   },
   "devDependencies": {
     "@ember/test-helpers": "^2.4.0",
-    "@embroider/test-setup": "^0.43.5",
     "babel-eslint": "^10.1.0",
     "ember-cli": "~3.27.0",
     "ember-cli-dependency-checker": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1325,14 +1325,6 @@
     resolve "^1.8.1"
     semver "^7.3.2"
 
-"@embroider/test-setup@^0.43.5":
-  version "0.43.5"
-  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-0.43.5.tgz#79944cb50038802cc71d50aa0d5d7a0955ee6349"
-  integrity sha512-ke+5B0VR2343ZrOqV9Ok2LyA4m2q2ApM1Oy1RC8+3+OI5lDVg8UgZG9n/G2e77KPMFxnK3eVpXcPdLcdOxW6+w==
-  dependencies:
-    lodash "^4.17.21"
-    resolve "^1.20.0"
-
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"


### PR DESCRIPTION
@embroider/test-setup has dropped support for node 10, but this project also still depends on node 10 until ember ~4.4… so this fixes that.