### PR TITLE
Allow ember-auto-import v1 or v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "broccoli-funnel": "^3.0.8",
     "broccoli-merge-trees": "^3.0.2",
     "common-tags": "^1.8.0",
-    "ember-auto-import": "^1.11.3",
+    "ember-auto-import": ">= ^1.11.3 < 3",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-test-loader": "^3.0.0",
     "resolve-package-path": "^3.1.0",
@@ -70,6 +70,9 @@
   "peerDependencies": {
     "@ember/test-helpers": "^2.4.0",
     "qunit": "^2.13.0"
+  },
+  "resolutions": {
+    "ember-auto-import": "^1.11.3"
   },
   "engines": {
     "node": "10.* || 12.* || >= 14.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4686,10 +4686,10 @@ elliptic@^6.5.3:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-ember-auto-import@^1.11.3:
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.11.3.tgz#6e3384a7fbb163384a34546f2e902cd297b0e683"
-  integrity sha512-ekq/XCvsonESobFU30zjZ0I4XMy2E/2ZILCYWuQ1JdhcCSTYhnXDZcqRW8itUG7kbsPqAHT/XZ1LEZYm3seVwQ==
+"ember-auto-import@>= ^1.11.3 < 3", ember-auto-import@^1.11.3:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.12.0.tgz#52246b04891090e2608244e65c4c6af7710df12b"
+  integrity sha512-fzMGnyHGfUNFHchpLbJ98Vs/c5H2wZBMR9r/XwW+WOWPisZDGLUPPyhJQsSREPoUQ+o8GvyLaD/rkrKqW8bmgw==
   dependencies:
     "@babel/core" "^7.1.6"
     "@babel/preset-env" "^7.10.2"


### PR DESCRIPTION
Since this addon is still supporting node 10, it isn't _that_ easy to update to eai v2, as that requires node 12+.
So I first tried to set the dependency to `"ember-auto-import": "^1.11.3 || ^2.2.4"`, but that threw an error on install time that the node engine was incompatible. Weirdly, that even happened when also setting a yarn resolution to `^1.11.3` locally :thinking: 

Now, I ended up allowing `>= ^1.11.3 < 3`, and adding a local resolution to `^1.11.3`, which seemed to do the trick. As far as I can tell, this addon itself is not doing anything special with eai, so both v1 and v2 should generally work fine in a host app.

Once this addon drops support for node 10, we can remove the resolution (and do `yarn add webpack --dev`) and use eai 2 locally.

Closes https://github.com/emberjs/ember-qunit/issues/902