### PR TITLE
Drop support for Node < 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
-        with:
-          node-version: 10.x
       - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn test:ember
@@ -30,8 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
-        with:
-          node-version: 10.x
       - run: yarn install --no-lockfile
       - run: yarn test:ember
 
@@ -60,8 +56,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
-        with:
-          node-version: 12.x
       - name: install dependencies
         run: yarn install --frozen-lockfile
       - name: test

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ helpers contained in
 Requirements
 ------------------------------------------------------------------------------
 
-- Node.js 10 or above
+- Node.js 14 or above
 - Ember 3.8 or above
 - Ember CLI 3.8 or above
 
-If you need support for Node 4 or older Ember CLI versions please use v3.x
+If you need support for Node 13 or older Ember CLI versions please use v4.x
 of this addon.
 
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "qunit": "^2.13.0"
   },
   "engines": {
-    "node": "10.* || 12.* || >= 14.*"
+    "node": "14.* || 16.* || >= 17"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
@@ -111,7 +111,7 @@
     }
   },
   "volta": {
-    "node": "10.22.0",
-    "yarn": "1.22.4"
+    "node": "14.19.1",
+    "yarn": "1.22.18"
   }
 }


### PR DESCRIPTION
This PR drops node versions before 14. This is a breaking change.

Note that I also updated CI to just use the pinned node version from Volta, and while at it I also updated yarn to the latest version.

See https://github.com/emberjs/ember-qunit/pull/921