### PR TITLE
Add Ember 4.8 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           - ember-lts-3.24
           - ember-lts-3.28
           - ember-lts-4.4
+          - ember-lts-4.8
           - ember-release
           - ember-beta
           - ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -32,6 +32,14 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-4.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.4.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           dependencies: {


### PR DESCRIPTION
Ember 4.8 will become an LTS shortly (when 4.9 is released), this adds it to CI so that we are explicitly testing it.
