### PR TITLE
Ensure CI jobs timeout after 10 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v3
@@ -28,6 +29,7 @@ jobs:
   floating-dependencies:
     name: 'Floating Dependencies'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v3
@@ -37,8 +39,8 @@ jobs:
 
   try-scenarios:
     name: 'Try: ${{ matrix.ember-try-scenario }}'
-
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     needs: test
 


### PR DESCRIPTION
Prevents an accidentally hanging CI job from eating up all of our CI concurrency.
