### PR TITLE
support Ember v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "peerDependencies": {
     "@ember/test-helpers": "^2.9.3",
-    "ember-source": "^3.28 || ^4.0",
+    "ember-source": ">=3.28",
     "qunit": "^2.13.0"
   },
   "engines": {


### PR DESCRIPTION
Peer dependencies not allowing prereleases of Ember v5 is breaking CI pipeline of many addons.

Closes #1026 