### PR TITLE
add test helpers 3 to peers

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "webpack": "^5.75.0"
   },
   "peerDependencies": {
-    "@ember/test-helpers": "^2.9.3",
+    "@ember/test-helpers": "^2.9.3 || >= 3.0.0",
     "ember-source": ">=3.28",
     "qunit": "^2.13.0"
   },


### PR DESCRIPTION
This isn't enough to get `@ember/test-helpers` working.
We need to drop support for node 14 as well, which means, we may as well do a bunch of things that could be breaking, like the v2 conversion, which already drops node 14.

These PRs should be merged/reviewed in order, as they build on each other, so they'll get bigger and bigger unless the prior PRs are merged.
 - https://github.com/emberjs/ember-qunit/pull/1060
 - https://github.com/emberjs/ember-qunit/pull/1063
 - https://github.com/emberjs/ember-qunit/pull/1062
 - https://github.com/emberjs/ember-qunit/pull/1064
 
 _my preference_ would be to merge those above 4, and ignore this PR until the end (due to conflict resolution concerns)
