### PR TITLE
Remove hasEmberVersion

### DIFF
--- a/addon-test-support/adapter.js
+++ b/addon-test-support/adapter.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import * as QUnit from 'qunit';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 function unhandledRejectionAssertion(current, error) {
   let message, source;
@@ -59,22 +58,6 @@ let Adapter = Ember.Test.Adapter.extend({
       done();
     }
   },
-
-  // clobber default implementation of `exception` will be added back for Ember
-  // < 2.17 just below...
-  exception: null,
 });
-
-// Ember 2.17 and higher do not require the test adapter to have an `exception`
-// method When `exception` is not present, the unhandled rejection is
-// automatically re-thrown and will therefore hit QUnit's own global error
-// handler (therefore appropriately causing test failure)
-if (!hasEmberVersion(2, 17)) {
-  Adapter = Adapter.extend({
-    exception(error) {
-      unhandledRejectionAssertion(QUnit.config.current, error);
-    },
-  });
-}
 
 export default Adapter;

--- a/addon-test-support/adapter.js
+++ b/addon-test-support/adapter.js
@@ -1,29 +1,6 @@
 import Ember from 'ember';
 import * as QUnit from 'qunit';
 
-function unhandledRejectionAssertion(current, error) {
-  let message, source;
-
-  if (typeof error === 'object' && error !== null) {
-    message = error.message;
-    source = error.stack;
-  } else if (typeof error === 'string') {
-    message = error;
-    source = 'unknown source';
-  } else {
-    message = 'unhandledRejection occurred, but it had no message';
-    source = 'unknown source';
-  }
-
-  current.assert.pushResult({
-    result: false,
-    actual: false,
-    expected: true,
-    message: message,
-    source: source,
-  });
-}
-
 export function nonTestDoneCallback() {}
 
 let Adapter = Ember.Test.Adapter.extend({

--- a/tests/acceptance/basic-test.js
+++ b/tests/acceptance/basic-test.js
@@ -10,13 +10,8 @@ import {
   click,
 } from '@ember/test-helpers';
 import { setResolverRegistry } from '../helpers/resolver';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('setupApplicationTest tests', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   const Router = EmberRouter.extend({ location: 'none' });
   Router.map(function () {
     this.route('widgets');

--- a/tests/integration/setup-rendering-test-test.js
+++ b/tests/integration/setup-rendering-test-test.js
@@ -5,13 +5,8 @@ import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { setResolverRegistry } from '../helpers/resolver';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('setupRenderingTest tests', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   hooks.beforeEach(function () {
     setResolverRegistry({});
   });

--- a/tests/integration/setup-test-test.js
+++ b/tests/integration/setup-test-test.js
@@ -2,14 +2,9 @@ import { module, test } from 'qunit';
 import Service, { inject as injectService } from '@ember/service';
 import Component from '@ember/component';
 import { setupTest } from 'ember-qunit';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { setResolverRegistry } from '../helpers/resolver';
 
 module('setupTest tests', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   hooks.beforeEach(function () {
     setResolverRegistry({});
   });
@@ -63,12 +58,7 @@ module('setupTest tests', function (hooks) {
       })
     );
 
-    let subject;
-    if (hasEmberVersion(2, 12)) {
-      subject = this.owner.lookup('component:foo-bar');
-    } else {
-      subject = this.owner._lookupFactory('component:foo-bar').create();
-    }
+    let subject = this.owner.lookup('component:foo-bar');
 
     assert.equal(subject.someMethod(), 'hello thar!');
   });


### PR DESCRIPTION
This was only used to support ember in the v2 series -- which is well past its expiration.

Yay deleting code!