### PR TITLE
Add push-dist workflow

### DIFF
--- a/.github/workflows/push-dist.yml
+++ b/.github/workflows/push-dist.yml
@@ -1,0 +1,20 @@
+name: Push dist
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  push-dist:
+    name: Push dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: volta-cli/action@v4
+      - run: yarn install --frozen-lockfile
+      - uses: kategengler/put-built-npm-package-contents-on-branch@v1.0.0
+        with:
+          branch: dist
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
ember-qunit is easy because it's not written in typescript, and has separate type-declarations, so there is no build/prepack to worry about 

(yet -- this workflow would be a good thing to compare against when the v2 PR is finally merged -- https://github.com/emberjs/ember-qunit/pull/1064 (this is the end of a 4PR series, with _all_ changes present in that PR until the other 3 are merged))