### PR TITLE
Add types directory in the publish output

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -24,6 +24,7 @@
   },
   "files": [
     "dist",
+    "types",
     "addon-main.cjs"
   ],
   "types": "types/index.d.ts",


### PR DESCRIPTION
I noticed this when I was looking at the `dist` branch generated on this repo. 😅 