### PR TITLE
Allow ember-source v5 as peerDependencies

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "@ember/test-helpers": ">=3.0.3",
-    "ember-source": ">=4.0.0",
+    "ember-source": ">=4.0.0 || >=5.0.0",
     "qunit": "^2.13.0"
   },
   "publishConfig": {


### PR DESCRIPTION
fix #1118