### PR TITLE
Add 'types' to package.json#exports because newer typescript versions ignore the package.json#types entry when package.json#exports is present

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -18,7 +18,10 @@
     "Steve Calvert"
   ],
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "./*": "./dist/*.js",
     "./addon-main.js": "./addon-main.cjs"
   },


### PR DESCRIPTION
Resolves:
```
Could not find a declaration file for module 'ember-qunit'. 
'<repo>/node_modules/.pnpm/ember-qunit@8.0.0_@ember+test-helpers@3.2.0_@glint+template@1.1.0_ember-source@5.2.0_qunit@2.19.4/node_modules/ember-qunit/dist/index.js' 
implicitly has an 'any' type.

There are types at '<repo>/node_modules/ember-qunit/types/index.d.ts', 
but this result could not be resolved when respecting package.json "exports". 

The 'ember-qunit' library may need to update its package.json or typings.
```

Tested locally via pnpm patch, with this patchfile:
```diff
diff --git a/package.json b/package.json
index 9a4a8bb4463d899cc7122145f5dbef54b0e85b71..751d5a1b7aca8ddffab8d8515a70994a5d4cf1a3 100644
--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "Steve Calvert"
   ],
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "./*": "./dist/*.js",
     "./addon-main.js": "./addon-main.cjs"
   },

```

Passing ts-matrix ensures no regressions.