### PR TITLE
Remove the "Disable linting" checkbox

### DIFF
--- a/addon/src/qunit-configuration.js
+++ b/addon/src/qunit-configuration.js
@@ -2,7 +2,6 @@ import * as QUnit from 'qunit';
 
 QUnit.config.autostart = false;
 QUnit.config.urlConfig.push({ id: 'nocontainer', label: 'Hide container' });
-QUnit.config.urlConfig.push({ id: 'nolint', label: 'Disable Linting' });
 QUnit.config.urlConfig.push({ id: 'devmode', label: 'Development mode' });
 
 QUnit.config.testTimeout = QUnit.urlParams.devmode ? null : 60000; //Default Test Timeout 60 Seconds

--- a/addon/src/test-loader.js
+++ b/addon/src/test-loader.js
@@ -1,12 +1,7 @@
 import * as QUnit from 'qunit';
 import AbstractTestLoader, {
-  addModuleExcludeMatcher,
   addModuleIncludeMatcher,
 } from 'ember-cli-test-loader/test-support/index';
-
-addModuleExcludeMatcher(function (moduleName) {
-  return QUnit.urlParams.nolint && moduleName.match(/\.(jshint|lint-test)$/);
-});
 
 addModuleIncludeMatcher(function (moduleName) {
   return moduleName.match(/\.jshint$/);
@@ -46,13 +41,6 @@ export class TestLoader extends AbstractTestLoader {
    Load tests following the default patterns:
 
    * The module name ends with `-test`
-   * The module name ends with `.jshint`
-
-   Excludes tests that match the following
-   patterns when `?nolint` URL param is set:
-
-   * The module name ends with `.jshint`
-   * The module name ends with `-lint-test`
 
    @method loadTests
  */


### PR DESCRIPTION
Addresses #1139.

This PR does two things:

1. It removes the "Disable linting" checkbox
2. It removes references to the `nolint` query param from the implementation

Removing the checkbox is my main goal with this PR, whereas removing references to `nolint` is just me being thorough. It's possible that we want to keep the `nolint` handling in place for the sake of backwards compatibility, in which case I'm happy to revert the second change.

Before:

<img width="775" alt="qunit-nolint-before" src="https://github.com/emberjs/ember-qunit/assets/7069/90535dd1-17b2-4f68-9bfb-d063670bef4d">

After:

<img width="770" alt="qunit-nolint-after" src="https://github.com/emberjs/ember-qunit/assets/7069/fba3a751-cfbc-424f-9402-2a7ffca0508d">
