### PR TITLE
feat: introduce `theme` config and add `qunit-theme-ember` as option

### DIFF
--- a/addon/README.md
+++ b/addon/README.md
@@ -189,6 +189,13 @@ module.exports = function (defaults) {
            * removes the CSS for the test-container (where the app and components are rendered to)
            */
           disableContainerStyles: true,
+          /**
+           * default: 'ember'
+           * options: 'ember' | 'qunit-default'
+           * 
+           * Sets the theme for the Web UI of the test runner. Use a different value to disable loading any theme, allowing you to provide your own external one.
+           */
+          theme: 'ember',
         },
       },
     },

--- a/addon/README.md
+++ b/addon/README.md
@@ -190,12 +190,12 @@ module.exports = function (defaults) {
            */
           disableContainerStyles: true,
           /**
-           * default: 'ember'
-           * options: 'ember' | 'qunit-default'
+           * default: 'qunit-default'
+           * options: 'qunit-default' | 'ember'
            * 
            * Sets the theme for the Web UI of the test runner. Use a different value to disable loading any theme, allowing you to provide your own external one.
            */
-          theme: 'ember',
+          theme: 'qunit-default',
         },
       },
     },

--- a/addon/package.json
+++ b/addon/package.json
@@ -44,7 +44,7 @@
     "@embroider/addon-shim": "^1.8.6",
     "@embroider/macros": "^1.13.1",
     "ember-cli-test-loader": "^3.1.0",
-    "qunit-theme-ember": "^0.2.0"
+    "qunit-theme-ember": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",

--- a/addon/package.json
+++ b/addon/package.json
@@ -43,7 +43,8 @@
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
     "@embroider/macros": "^1.13.1",
-    "ember-cli-test-loader": "^3.1.0"
+    "ember-cli-test-loader": "^3.1.0",
+    "qunit-theme-ember": "^0.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",

--- a/addon/src/index.js
+++ b/addon/src/index.js
@@ -18,11 +18,7 @@ if (macroCondition(!getOwnConfig()?.disableContainerStyles)) {
   importSync('./test-container-styles.css');
 }
 
-if (
-  macroCondition(
-    getOwnConfig()?.theme === undefined || getOwnConfig()?.theme === 'ember'
-  )
-) {
+if (macroCondition(getOwnConfig()?.theme === 'ember')) {
   importSync('qunit-theme-ember/qunit.css');
 }
 

--- a/addon/src/index.js
+++ b/addon/src/index.js
@@ -1,5 +1,6 @@
 /* globals Testem */
 import 'qunit/qunit/qunit.css';
+import 'qunit-theme-ember/qunit.css';
 
 import { macroCondition, getOwnConfig, importSync } from '@embroider/macros';
 

--- a/addon/src/index.js
+++ b/addon/src/index.js
@@ -2,7 +2,7 @@
 import { macroCondition, getOwnConfig, importSync } from '@embroider/macros';
 
 /**
- * Load qunit-theme-ember by default, if no custom theme is specified.
+ * Load qunit-default theme by default, if no custom theme is specified.
  */
 if (
   macroCondition(

--- a/addon/src/index.js
+++ b/addon/src/index.js
@@ -1,13 +1,30 @@
 /* globals Testem */
-import 'qunit/qunit/qunit.css';
-
 import { macroCondition, getOwnConfig, importSync } from '@embroider/macros';
+
+/**
+ * Load qunit-theme-ember by default, if no custom theme is specified.
+ */
+if (
+  macroCondition(
+    getOwnConfig()?.theme === undefined ||
+      getOwnConfig()?.theme === 'qunit-default' ||
+      getOwnConfig()?.theme === 'ember'
+  )
+) {
+  importSync('qunit/qunit/qunit.css');
+}
 
 if (macroCondition(!getOwnConfig()?.disableContainerStyles)) {
   importSync('./test-container-styles.css');
 }
 
-importSync('qunit-theme-ember/qunit.css');
+if (
+  macroCondition(
+    getOwnConfig()?.theme === undefined || getOwnConfig()?.theme === 'ember'
+  )
+) {
+  importSync('qunit-theme-ember/qunit.css');
+}
 
 export { default as QUnitAdapter, nonTestDoneCallback } from './adapter';
 export { loadTests } from './test-loader';

--- a/addon/src/index.js
+++ b/addon/src/index.js
@@ -1,12 +1,13 @@
 /* globals Testem */
 import 'qunit/qunit/qunit.css';
-import 'qunit-theme-ember/qunit.css';
 
 import { macroCondition, getOwnConfig, importSync } from '@embroider/macros';
 
 if (macroCondition(!getOwnConfig()?.disableContainerStyles)) {
   importSync('./test-container-styles.css');
 }
+
+import 'qunit-theme-ember/qunit.css';
 
 export { default as QUnitAdapter, nonTestDoneCallback } from './adapter';
 export { loadTests } from './test-loader';

--- a/addon/src/index.js
+++ b/addon/src/index.js
@@ -7,7 +7,7 @@ if (macroCondition(!getOwnConfig()?.disableContainerStyles)) {
   importSync('./test-container-styles.css');
 }
 
-import 'qunit-theme-ember/qunit.css';
+importSync('qunit-theme-ember/qunit.css');
 
 export { default as QUnitAdapter, nonTestDoneCallback } from './adapter';
 export { loadTests } from './test-loader';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
       qunit-theme-ember:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^1.0.0
+        version: 1.0.0
     devDependencies:
       '@babel/core':
         specifier: ^7.23.2
@@ -11401,8 +11401,8 @@ packages:
       - supports-color
     dev: true
 
-  /qunit-theme-ember@0.2.0:
-    resolution: {integrity: sha512-o2j4MoGspsGBnPmWk87/vPHmIsvKNzwCtymbc8bpRxCBVgF1JW5ry2uIFi4XYDY8k6RcL9ashCDHiSjzbn8oqw==}
+  /qunit-theme-ember@1.0.0:
+    resolution: {integrity: sha512-vdMVVo6ecdCkWttMTKeyq1ZTLGHcA6zdze2zhguNuc3ritlJMhOXY5RDseqazOwqZVfCg3rtlmL3fMUyIzUyFQ==}
     dev: false
 
   /qunit@2.20.0:
@@ -13913,6 +13913,7 @@ packages:
       ember-cli-test-loader: 3.1.0
       ember-source: 5.0.0(@babel/core@7.23.2)(@glimmer/component@1.1.2)(webpack@5.86.0)
       qunit: 2.20.0
+      qunit-theme-ember: 1.0.0
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       ember-cli-test-loader:
         specifier: ^3.1.0
         version: 3.1.0
+      qunit-theme-ember:
+        specifier: ^0.2.0
+        version: 0.2.0
     devDependencies:
       '@babel/core':
         specifier: ^7.23.2
@@ -11397,6 +11400,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /qunit-theme-ember@0.2.0:
+    resolution: {integrity: sha512-o2j4MoGspsGBnPmWk87/vPHmIsvKNzwCtymbc8bpRxCBVgF1JW5ry2uIFi4XYDY8k6RcL9ashCDHiSjzbn8oqw==}
+    dev: false
 
   /qunit@2.20.0:
     resolution: {integrity: sha512-N8Fp1J55waE+QG1KwX2LOyqulZUToRrrPBqDOfYfuAMkEglFL15uwvmH1P4Tq/omQ/mGbBI8PEB3PhIfvUb+jg==}

--- a/test-buildtime-options-app/ember-cli-build.js
+++ b/test-buildtime-options-app/ember-cli-build.js
@@ -11,6 +11,7 @@ module.exports = function (defaults) {
       setConfig: {
         'ember-qunit': {
           disableContainerStyles: true,
+          theme: 'qunit-default',
         },
       },
     },

--- a/test-buildtime-options-app/tests/unit/theme-test.js
+++ b/test-buildtime-options-app/tests/unit/theme-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { assert as debugAssert } from '@ember/debug';
+
+module('theme', function () {
+  function style(element) {
+    return window.getComputedStyle(element);
+  }
+
+  test('the qunit-default themes are present when used', async function (assert) {
+    let qunitHeader = document.getElementById('qunit-header');
+
+    debugAssert(`#qunit-header must exist`, qunitHeader);
+
+    // Defaults
+    assert.strictEqual(style(qunitHeader).backgroundColor, 'rgb(13, 51, 73)');
+  });
+});


### PR DESCRIPTION
Introduces a `theme` config option and adds [qunit-theme-ember](https://github.com/IgnaceMaes/qunit-theme-ember) as option.

| Before | After |
| --- | --- |
| ![preview2](https://github.com/emberjs/ember-qunit/assets/10243652/f69d638f-645c-4e54-9572-960dc5d80807) | ![image](https://github.com/emberjs/ember-qunit/assets/10243652/bb712f69-e8fc-454a-a45e-ca083f39b4e5) |

In a follow-up PR, this can be made the default. This can first be released as a minor, and switching the default to Ember would be a major.
