### PR TITLE
Remove pauseTest workaround

### DIFF
--- a/addon/src/index.js
+++ b/addon/src/index.js
@@ -44,12 +44,6 @@ export function setupTest(hooks, _options) {
       let originalPauseTest = this.pauseTest;
       this.pauseTest = function QUnit_pauseTest() {
         assert.timeout(-1); // prevent the test from timing out
-
-        // This is a temporary work around for
-        // https://github.com/emberjs/ember-qunit/issues/496 this clears the
-        // timeout that would fail the test when it hits the global testTimeout
-        // value.
-        clearTimeout(QUnit.config.timeout);
         return originalPauseTest.call(this);
       };
     });


### PR DESCRIPTION
Follows-up https://github.com/emberjs/ember-qunit/pull/497 which introduced this because QUnit 2.8 didn't support changing an existing `assert.timeout()` by calling it again in the same test (it would leave the old one unchanged, and start a second timeout).

This was fixed in QUnit 2.9.3, released in Oct 2019.

The ember-qunit package declares a peer dependency on `qunit@2.13.0`, which should remove the need for this workaround.

Ref https://github.com/emberjs/ember-qunit/issues/496.