### PR TITLE
Fix @typs/qunit overrides for latest qunit version

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -55,7 +55,7 @@
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "@rollup/plugin-babel": "^5.3.0",
     "@tsconfig/ember": "^2.0.0",
-    "@types/qunit": "^2.19.6",
+    "@types/qunit": "^2.19.12",
     "@types/rsvp": "^4.0.4",
     "concurrently": "^8.0.1",
     "ember-source": "^5.0.0",

--- a/addon/types/index.d.ts
+++ b/addon/types/index.d.ts
@@ -180,30 +180,6 @@ declare global {
 
   interface QUnit {
     /**
-     * Add a test to run.
-     *
-     * Add a test to run using `QUnit.test()`.
-     *
-     * The `assert` argument to the callback contains all of QUnit's assertion
-     * methods. Use this argument to call your test assertions.
-     *
-     * `QUnit.test()` can automatically handle the asynchronous resolution of a
-     * Promise on your behalf if you return a thenable Promise as the result of
-     * your callback function.
-     *
-     * @param name Title of unit being tested
-     * @param callback Function to close over assertions
-     */
-    // SAFETY: this is just wildly, impossibly unsafe. QUnit cannot -- ever! --
-    // provide this guarantee. However, it's also the only way to support TS
-    // in tests in Ember until we move the community over entirely to using
-    // `<template>` and local scope.
-    test<TC extends TestContext>(
-      name: string,
-      callback: (this: TC, assert: Assert) => void | Promise<unknown>
-    ): void;
-
-    /**
      * Adds a test to exclusively run, preventing all other tests from running.
      *
      * Use this method to focus your test suite on a specific test. QUnit.only
@@ -268,5 +244,47 @@ declare global {
       name: string,
       callback?: (this: TC, assert: Assert) => void | Promise<unknown>
     ): void;
+  }
+
+  namespace QUnit {
+    interface TestFunction {
+      // SAFETY: this is just wildly, impossibly unsafe. QUnit cannot -- ever! --
+      // provide this guarantee. However, it's also the only way to support TS
+      // in tests in Ember until we move the community over entirely to using
+      // `<template>` and local scope.
+      <TC extends TestContext>(
+        name: string,
+        callback: (this: TC, assert: Assert) => void | Promise<unknown>
+      ): void;
+    }
+
+    interface SkipFunction {
+      <TC extends TestContext>(
+        name: string,
+        callback?: (this: TC, assert: Assert) => void | Promise<unknown>
+      ): void;
+    }
+
+    interface TodoFunction {
+      <TC extends TestContext>(
+        name: string,
+        callback?: (this: TC, assert: Assert) => void | Promise<unknown>
+      ): void;
+    }
+
+    interface OnlyFunction {
+      <TC extends TestContext>(
+        name: string,
+        callback: (this: TC, assert: Assert) => void | Promise<unknown>
+      ): void;
+    }
+
+    interface EachFunction {
+      <TC extends TestContext, T>(
+         name: string,
+         dataset: T[],
+         callback: (this: TC, assert: Assert, data: T) => void | Promise<unknown>
+       ): void;
+   }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       '@types/qunit':
-        specifier: ^2.19.6
-        version: 2.19.6
+        specifier: ^2.19.12
+        version: 2.19.12
       '@types/rsvp':
         specifier: ^4.0.4
         version: 4.0.4
@@ -133,8 +133,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       '@types/qunit':
-        specifier: ^2.19.6
-        version: 2.19.6
+        specifier: ^2.19.12
+        version: 2.19.12
       '@types/rsvp':
         specifier: ^4.0.4
         version: 4.0.4
@@ -269,8 +269,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       '@types/qunit':
-        specifier: ^2.19.6
-        version: 2.19.6
+        specifier: ^2.19.12
+        version: 2.19.12
       '@types/rsvp':
         specifier: ^4.0.4
         version: 4.0.4
@@ -387,8 +387,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       '@types/qunit':
-        specifier: ^2.19.6
-        version: 2.19.6
+        specifier: ^2.19.12
+        version: 2.19.12
       ember-cli-htmlbars:
         specifier: ^6.3.0
         version: 6.3.0
@@ -3416,8 +3416,8 @@ packages:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
     dev: true
 
-  /@types/qunit@2.19.6:
-    resolution: {integrity: sha512-bz9STa6EHurtpSfn5cNiScBladlw43bM+7luQA985Kd9YlF4dZaLmKt3c5/oSyN1AWAl50YBpqTq0BxCP64nGg==}
+  /@types/qunit@2.19.12:
+    resolution: {integrity: sha512-II+C1wgzUia0g+tGAH+PBb4XiTm8/C/i6sN23r21NNskBYOYrv+qnW0tFQ/IxZzKVwrK4CTglf8YO3poJUclQA==}
     dev: true
 
   /@types/range-parser@1.2.4:
@@ -13902,6 +13902,7 @@ packages:
     resolution: {directory: addon, type: directory}
     id: file:addon
     name: ember-qunit
+    version: 8.1.0
     peerDependencies:
       '@ember/test-helpers': '>=3.0.3'
       ember-source: '>=4.0.0'

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -41,7 +41,7 @@
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@tsconfig/ember": "^2.0.0",
-    "@types/qunit": "^2.19.6",
+    "@types/qunit": "^2.19.12",
     "@types/rsvp": "^4.0.4",
     "concurrently": "^8.0.1",
     "ember-angle-bracket-invocation-polyfill": "^3.0.2",

--- a/test-buildtime-options-app/package.json
+++ b/test-buildtime-options-app/package.json
@@ -41,7 +41,7 @@
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@tsconfig/ember": "^2.0.0",
-    "@types/qunit": "^2.19.6",
+    "@types/qunit": "^2.19.12",
     "@types/rsvp": "^4.0.4",
     "concurrently": "^8.0.1",
     "ember-angle-bracket-invocation-polyfill": "^3.0.2",

--- a/test-types/package.json
+++ b/test-types/package.json
@@ -14,7 +14,7 @@
     "@ember/test-helpers": "^3.0.3",
     "@glimmer/component": "^1.1.2",
     "@tsconfig/ember": "^2.0.0",
-    "@types/qunit": "^2.19.6",
+    "@types/qunit": "^2.19.12",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-resolver": "^10.1.0",
     "ember-source": "^5.0.0",

--- a/test-types/src/tests.ts
+++ b/test-types/src/tests.ts
@@ -337,3 +337,45 @@ module('with setup options', function (hooks) {
   setupRenderingTest(hooks, { resolver });
   setupApplicationTest(hooks, { resolver });
 });
+
+module('methods on test function', function () {
+  test.each('example with each', [1,2,3], async function (assert, number) {
+    // setup the outer context
+    this.set('value', 'cat');
+  
+    await render(hbs`{{number}}`);
+  
+    assert.strictEqual(number, 1)
+  });
+
+  test.skip('example with skip', async function (assert) {
+    // setup the outer context
+    this.set('value', 'cat');
+  
+    await render(hbs`{{number}}`);
+
+    assert.ok(this.get('value'));
+  });
+
+  test.skip('example with skip w/o callback');
+
+  test.todo('example with todo', async function (assert) {
+    // setup the outer context
+    this.set('value', 'cat');
+  
+    await render(hbs`{{number}}`);
+
+    assert.ok(this.get('value'));
+  });
+
+  test.todo('example with todo w/o callback');
+
+  test.only('example with only', async function (assert) {
+    // setup the outer context
+    this.set('value', 'cat');
+  
+    await render(hbs`{{number}}`);
+
+    assert.ok(this.get('value'));
+  });
+})


### PR DESCRIPTION
With the latest updates to `@types/qunit`:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70946
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71036

The type overrides that we have in here stopped working, this PR fixes them so they work with latest `@types/qunit` version.