### PR TITLE
Require explicit calls to loadTests and setupEmberOnerrorValidation

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -22,7 +22,10 @@
       "types": "./types/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./*": "./dist/*.js",
+    "./*": {
+      "types": "./types/*.d.ts",
+      "default": "./dist/*.js"
+    },
     "./addon-main.js": "./addon-main.cjs"
   },
   "files": [
@@ -30,7 +33,13 @@
     "types",
     "addon-main.cjs"
   ],
-  "types": "types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "types/*"
+      ]
+    }
+  },
   "scripts": {
     "build": "rollup --config",
     "lint": "concurrently 'npm:lint:*(!fix)' --names 'lint:'",

--- a/addon/package.json
+++ b/addon/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
     "@embroider/macros": "^1.13.1",
-    "ember-cli-test-loader": "^3.1.0",
     "qunit-theme-ember": "^1.0.0"
   },
   "devDependencies": {

--- a/addon/src/index.js
+++ b/addon/src/index.js
@@ -187,8 +187,6 @@ export function setupTestIsolationValidation(delay) {
    @param {Boolean} [options.setupEmberTesting] `false` opts out of the
    default behavior of setting `Ember.testing` to `true` before all tests and
    back to `false` after each test will.
-   @param {Boolean} [options.setupEmberOnerrorValidation] If `false` validation
-   of `Ember.onerror` will be disabled.
    @param {Boolean} [options.setupTestIsolationValidation] If `false` test isolation validation
    will be disabled.
    @param {Number} [options.testIsolationValidationDelay] When using
@@ -207,10 +205,6 @@ export function start(options = {}) {
 
   if (options.setupEmberTesting !== false) {
     setupEmberTesting();
-  }
-
-  if (options.setupEmberOnerrorValidation !== false) {
-    setupEmberOnerrorValidation();
   }
 
   if (

--- a/addon/src/index.js
+++ b/addon/src/index.js
@@ -23,7 +23,6 @@ if (macroCondition(getOwnConfig()?.theme === 'ember')) {
 }
 
 export { default as QUnitAdapter, nonTestDoneCallback } from './adapter';
-export { loadTests } from './test-loader';
 
 import './qunit-configuration';
 
@@ -33,7 +32,6 @@ if (typeof Testem !== 'undefined') {
 
 import { _backburner } from '@ember/runloop';
 import { resetOnerror, getTestMetadata } from '@ember/test-helpers';
-import { loadTests } from './test-loader';
 import Ember from 'ember';
 import * as QUnit from 'qunit';
 import QUnitAdapter from './adapter';
@@ -180,7 +178,6 @@ export function setupTestIsolationValidation(delay) {
 /**
    @method start
    @param {Object} [options] Options to be used for enabling/disabling behaviors
-   @param {Boolean} [options.loadTests] If `false` tests will not be loaded automatically.
    @param {Boolean} [options.setupTestContainer] If `false` the test container will not
    be setup based on `devmode`, `dockcontainer`, or `nocontainer` URL params.
    @param {Boolean} [options.startTests] If `false` tests will not be automatically started
@@ -200,10 +197,6 @@ export function setupTestIsolationValidation(delay) {
    async to have been completed. The default value is 50.
  */
 export function start(options = {}) {
-  if (options.loadTests !== false) {
-    loadTests();
-  }
-
   if (options.setupTestContainer !== false) {
     setupTestContainer();
   }

--- a/addon/types/index.d.ts
+++ b/addon/types/index.d.ts
@@ -112,15 +112,12 @@ interface QUnitStartOptions {
   setupEmberTesting?: boolean | undefined;
 
   /**
-   * If `false` validation of `Ember.onerror` will be disabled.
-   */
-  setupEmberOnerrorValidation?: boolean | undefined;
-
-  /**
    * If `false` test isolation validation will be disabled.
    */
   setupTestIsolationValidation?: boolean | undefined;
 }
+
+export function setupEmberOnerrorValidation(): void;
 
 export function start(options?: QUnitStartOptions): void;
 
@@ -276,10 +273,10 @@ declare global {
 
     interface EachFunction {
       <TC extends TestContext, T>(
-         name: string,
-         dataset: T[],
-         callback: (this: TC, assert: Assert, data: T) => void | Promise<unknown>
-       ): void;
-   }
+        name: string,
+        dataset: T[],
+        callback: (this: TC, assert: Assert, data: T) => void | Promise<unknown>
+      ): void;
+    }
   }
 }

--- a/addon/types/index.d.ts
+++ b/addon/types/index.d.ts
@@ -89,11 +89,6 @@ export { module, test, skip, only, todo } from 'qunit';
 
 interface QUnitStartOptions {
   /**
-   * If `false` tests will not be loaded automatically.
-   */
-  loadTests?: boolean | undefined;
-
-  /**
    * If `false` the test container will not be setup based on `devmode`,
    * `dockcontainer`, or `nocontainer` URL params.
    */

--- a/addon/types/test-loader.d.ts
+++ b/addon/types/test-loader.d.ts
@@ -1,0 +1,1 @@
+export function loadTests(): void;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,9 +16,6 @@ importers:
       '@embroider/macros':
         specifier: ^1.13.1
         version: 1.13.1
-      ember-cli-test-loader:
-        specifier: ^3.1.0
-        version: 3.1.0
       qunit-theme-ember:
         specifier: ^1.0.0
         version: 1.0.0
@@ -3680,9 +3677,6 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependenciesMeta:
-      ajv:
-        optional: true
     dependencies:
       ajv: 8.11.0
 
@@ -13902,7 +13896,6 @@ packages:
     resolution: {directory: addon, type: directory}
     id: file:addon
     name: ember-qunit
-    version: 8.1.0
     peerDependencies:
       '@ember/test-helpers': '>=3.0.3'
       ember-source: '>=4.0.0'

--- a/test-app/tests/test-helper.js
+++ b/test-app/tests/test-helper.js
@@ -4,11 +4,12 @@ import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
 import { loadTests } from 'ember-qunit/test-loader';
-import { start } from 'ember-qunit';
+import { start, setupEmberOnerrorValidation } from 'ember-qunit';
 
 setApplication(Application.create(config.APP));
 
 setup(QUnit.assert);
 
+setupEmberOnerrorValidation();
 loadTests();
 start();

--- a/test-app/tests/test-helper.js
+++ b/test-app/tests/test-helper.js
@@ -3,10 +3,12 @@ import config from 'test-app/config/environment';
 import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
+import { loadTests } from 'ember-qunit/test-loader';
 import { start } from 'ember-qunit';
 
 setApplication(Application.create(config.APP));
 
 setup(QUnit.assert);
 
+loadTests();
 start();

--- a/test-app/types/index.d.ts
+++ b/test-app/types/index.d.ts
@@ -87,6 +87,8 @@ export class QUnitAdapter extends EmberTestAdapter {}
 
 export { module, test, skip, only, todo } from 'qunit';
 
+export function setupEmberOnerrorValidation(): void;
+
 interface QUnitStartOptions {
   /**
    * If `false` tests will not be loaded automatically.
@@ -115,11 +117,6 @@ interface QUnitStartOptions {
    * to `true` before all tests and back to `false` after each test will.
    */
   setupEmberTesting?: boolean | undefined;
-
-  /**
-   * If `false` validation of `Ember.onerror` will be disabled.
-   */
-  setupEmberOnerrorValidation?: boolean | undefined;
 
   /**
    * If `false` test isolation validation will be disabled.


### PR DESCRIPTION
This makes `start` from `ember-qunit` really only responsible for starting tests, and splits test loading into `loadTests()` and the classical onError validation into `setupEmberOnerrorValidation`. It's necessary because test loading is a classic AMD concept that's not wanted in new-style apps building with Embroider. Also we want to drop the dependency on ember-cli-test-loader because that is a v1 addon.

To keep the classic behavior, the blueprint will change like:

```diff
+import { loadTests } from 'ember-qunit/test-loader';
-import { start } from 'ember-qunit';
+import { start, setupEmberOnerrorValidation } from 'ember-qunit';
+setupEmberOnerrorValidation();
+loadTests();
start();
```

Note that `setupEmberOnerrorValidation` was already an exported function, it was just missing a type declaration. We decided to drop this from happening automatically because it protects people during this upgrade: if they don't change their blueprint at all, they will get a failing test suite with no tests in it. Had we kept the automatic OnError validation, the presence of that test would cause a spurious passing test suite when you fail to call `loadTests()`.


~This is still draft because we need to confirm the TS support in some real apps both with and without `moduleResolution: "nodenext"`.~ I tested this under both moduleResolution modes.