### PR TITLE
Export TestLoader

### DIFF
--- a/addon/src/test-loader.js
+++ b/addon/src/test-loader.js
@@ -2,7 +2,7 @@
 
 import * as QUnit from 'qunit';
 
-class TestLoader {
+export class TestLoader {
   static load() {
     new TestLoader().loadModules();
   }


### PR DESCRIPTION
Apparently other packages (like ember-exam) rely on extending `TestLoader`. There's no reason we can't keep exporting it. Although those packages are advised they should stop relying on AMD-dependent APIs like that or they're going to prevent apps from using Vite, etc.