### PR TITLE
Remove unneeded peer declaration

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -79,7 +79,6 @@
   },
   "peerDependencies": {
     "@ember/test-helpers": ">=3.0.3",
-    "ember-source": ">=4.0.0",
     "qunit": "^2.13.0"
   },
   "publishConfig": {


### PR DESCRIPTION
is extraneous, and the embroider/auto-import infra know where to get ember-source from. It's not _wrong_ to include, but it requires folks' manage their deps correctly -- so we can be a little more forgiving to maintainers by just omitting this.


From PR descriptions elsewhere:

- ember-source: removed because the embroider / auto-import know what we intend - it's not bad to have if someone manages their dep graph correctly, which is easier with pnpm, but not everyone gets it right, and folks have a hard time tracking down errors
- @glimmer/tracking removed because it's a real package, but one we don't want to use. This comes up in embroider/vite where the presence of real packages always takes precedence over virtual packages. This is actually problematic because it can break reactivity in subtle ways, even if a dep graph is correct - allowing duplicates of dependencies, which for the glimmer internals, we don't want.
 

Related:
- https://github.com/cibernox/ember-power-calendar/pull/550
- https://github.com/lifeart/ember-click-outside-modifier/pull/47
- https://github.com/tracked-tools/ember-async-data/pull/854
- https://github.com/emberjs/data/pull/9986
- https://github.com/ember-animation/ember-animated/pull/779
- https://github.com/tildeio/ember-element-helper/pull/125
- https://github.com/CrowdStrike/ember-headless-form/pull/574
- https://github.com/adopted-ember-addons/ember-sortable/pull/620
- https://github.com/ember-cli/ember-app-blueprint/pull/7
- https://github.com/ember-cli/ember-cli/pull/10697
- https://github.com/ember-cli/ember-addon-blueprint/pull/35
- https://github.com/embroider-build/addon-blueprint/pull/339
- https://github.com/ember-polyfills/ember-functions-as-helper-polyfill/pull/151
- https://github.com/jelhan/ember-style-modifier/pull/312
- https://github.com/jmurphyau/ember-truth-helpers/pull/211
- https://github.com/ember-modifier/ember-modifier/pull/949
- https://github.com/tracked-tools/tracked-toolbox/pull/211
- https://github.com/emberjs/ember-test-helpers/pull/1543
- https://github.com/NullVoxPopuli/ember-resources/pull/1189
- https://github.com/NullVoxPopuli/ember-modify-based-class-resource/pull/20
- https://github.com/universal-ember/kolay/pull/187
- https://github.com/universal-ember/reactiveweb/pull/139
- https://github.com/universal-ember/ember-primitives/pull/471
- https://github.com/universal-ember/docs-support/pull/77