### PR TITLE
Add types for object based test.each() datasets

### DIFF
--- a/addon/types/index.d.ts
+++ b/addon/types/index.d.ts
@@ -274,7 +274,7 @@ declare global {
     interface EachFunction {
       <TC extends TestContext, T>(
         name: string,
-        dataset: T[],
+        dataset: T[] | Record<string, T>,
         callback: (this: TC, assert: Assert, data: T) => void | Promise<unknown>
       ): void;
     }

--- a/test-types/src/tests.ts
+++ b/test-types/src/tests.ts
@@ -339,7 +339,16 @@ module('with setup options', function(hooks) {
 });
 
 module('methods on test function', function() {
-  test.each('example with each', [1, 2, 3], async function(assert, number) {
+  test.each('example with each (array dataset)', [1, 2, 3], async function(assert, number) {
+    // setup the outer context
+    this.set('value', 'cat');
+
+    await render(hbs`{{number}}`);
+
+    assert.strictEqual(number, 1)
+  });
+
+  test.each('example with each (object dataset)', { one: 1, two: 2, three: 3 }, async function(assert, number) {
     // setup the outer context
     this.set('value', 'cat');
 


### PR DESCRIPTION
Prior to this change, we only supported an array for the dataset type which causes the original `qunit` type definitions to resolve if the dataset is an object. The fallback will result in the `TestContect` being removed from the `this` and marking it as `any`.

According the QUnit docs if you pass an object instead of an array to test.each() the keys of the object become the test label while the values are the data passed to each run of the test.

This change unions the `T[]` with `Record<string, T>` so that both options can be used as expected.